### PR TITLE
Release v0.1.9

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# CopySpeak secrets — copy this file to `.env` next to copyspeak.exe and fill in.
+#
+# Place the real .env in the SAME directory as copyspeak.exe
+# (e.g. C:\Users\<you>\AppData\Local\CopySpeak\copyspeak.exe  ->  ...\CopySpeak\.env).
+# For `cargo tauri dev`, put it in src-tauri/target/debug/.
+#
+# Rules:
+#   - One KEY=VALUE per line. No quotes, no spaces around the value.
+#   - Lines starting with # are comments. Blank lines are ignored.
+#   - When a variable is set here, it OVERRIDES whatever key you typed in the
+#     CopySpeak UI (env wins). Leave a line commented to use the UI value instead.
+#   - The .env file is never modified or written by CopySpeak. The UI-typed keys
+#     stay in config.json; this file just layers on top.
+
+# ── TTS engines ───────────────────────────────────────────────────────────────
+# ElevenLabs  → https://elevenlabs.io/app/settings/api-keys
+ELEVENLABS_API_KEY=
+
+# OpenAI      → https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+
+# Cartesia    → https://play.cartesia.ai/ (Settings → API Keys)
+CARTESIA_API_KEY=
+
+# Google Gemini — GEMINI_API_KEY is preferred; GOOGLE_API_KEY works as an alias.
+#                → https://aistudio.google.com/apikey
+GEMINI_API_KEY=
+GOOGLE_API_KEY=
+
+# Microsoft MAI-Voice-2 (Azure AI Foundry)
+# MICROSOFT_API_KEY (or AZURE_API_KEY) + your deployment endpoint.
+MICROSOFT_API_KEY=
+AZURE_API_KEY=
+MICROSOFT_ENDPOINT=
+
+# ── Post-processing LLM (Groq Cloud / OpenAI-compatible) ───────────────────────
+# Used by the LLM text-cleanup step. → https://console.groq.com/keys
+POST_PROCESS_API_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,17 @@ DO NOT commit changes without explicit user confirmation. Before ending a task, 
 - `bun check` - types + svelte-check.
 - `bun build` - production build.
 
-Use running dev server. Test scroll, theme toggle, cursor.
+Use running Tauri dev server.
+
+## Efficiency
+
+- Read before write. Each file once.
+- Edit over rewrite. No write-delete-rewrite cycles.
+- Test once, fix, verify once.
+- Budget: 50 tool calls.
+- Stuck → ask. No dead ends.
+- No sycophantic openers/fluff.
+- Never guess paths.
 
 ## Code Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Searchable voice picker** — the flat per-engine voice `<Select>` in the profile editor is replaced by `voice-picker.svelte`: a portaled popover with a live search box, automatic grouping (by gender for OpenAI/Google/Cartesia/ElevenLabs, by BCP-47 locale for Edge), inline metadata (`gender · language`) and a check mark on the active voice. Escape / outside-click closes it; the panel flips above the trigger when space below is tight. The manual Voice ID input remains below it as the escape hatch.
+
+- **Cartesia voice refresh** — `supports_voice_refresh` is now `true` for Cartesia. New `CartesiaTtsBackend::list_voices()` calls `GET https://api.cartesia.ai/voices` (`X-API-Key` + `Cartesia-Version`) and maps results into `VoiceCatalogEntry`; on API failure `list_tts_voices` falls back to the static catalog list (mirroring the ElevenLabs pattern). The picker's Refresh button covers both ElevenLabs and Cartesia.
+
+- **`.env` secret loading** — CopySpeak now reads a `.env` file placed next to `copyspeak.exe` (in dev: `src-tauri/target/debug/`). Keys defined there override the values typed in the Engines UI; UI-typed keys in `config.json` remain the fallback. Env values are never written back to disk. See `.env.example` for the full variable list (`OPENAI_API_KEY`, `ELEVENLABS_API_KEY`, `CARTESIA_API_KEY`, `GEMINI_API_KEY`/`GOOGLE_API_KEY`, `MICROSOFT_API_KEY`/`AZURE_API_KEY` + `MICROSOFT_ENDPOINT`, `POST_PROCESS_API_KEY`).
+  - New `secrets.rs`: `load_dotenv()` (naive `KEY=VALUE` parser, called once after logging init in `main.rs`) and `resolve(config_val, env_names)` (env-wins resolution with alias support, e.g. Gemini accepts both `GEMINI_API_KEY` and `GOOGLE_API_KEY`).
+  - All credential read-sites now route through `secrets::resolve`: the five TTS backends (`openai`, `elevenlabs`, `cartesia`, `google`, `microsoft`), the three cloud credential-check commands, and the live Groq post-processing path (`post_process::process`).
+
+### Changed
+
+- **`VoiceCatalogEntry` gains a `gender` field** (`Option<String>`, serialized as `gender`) surfaced in `src/lib/types.ts`. `catalog.rs::voice()` helper now takes a `gender` argument.
+- **Enriched static voice metadata:**
+  - OpenAI (11 voices) — labels capitalized, gender + concise style description per voice.
+  - Google Gemini (29 voices) — gender + Google's documented style descriptor per voice; grouped Female/Male in the picker.
+  - Cartesia (2 static voices) — gender + description; language set to `None` (multilingual).
+  - Edge (30 voices) — `language` carries the BCP-47 locale parsed from the voice id (`en-US`, `en-GB`, …) and `gender` is now populated from the live `edge-tts --list-voices` metadata (Microsoft's published genders). The picker groups Edge by **locale** (region is the more useful cluster) with gender shown as per-row meta; cloud engines still group by gender. `en-US-DavisNeural` and `en-US-AmberNeural` are absent from the current live list (likely deprecated) and keep `gender: None`.
+  - ElevenLabs — static catalog expanded from 1 (Rachel) to **21 real premade voices**. IDs/names/genders fetched from `GET /v1/voices` (2026-07-06), each with an `"{accent} · {gender} · {style}"` description; `language` set to `None` since gender is the picker group key (avoids a redundant per-row `en`). Rachel was rotated out of the premade set and is dropped — still usable via the manual Voice ID escape hatch.
+
+### Fixed
+
+- **ElevenLabs voice metadata** — `list_tts_voices` now propagates the `gender` label from the ElevenLabs API into the catalog entry (previously dropped).
+
 ## [0.1.8] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-07-06
+
+### Added
+
+- **`has_engine_credentials` command** — New IPC command checks whether an engine has credentials available (config.json or .env) without making HTTP requests. Used by the profile manager to show/hide the "Set up engine credentials" hint accurately.
+
+- **Config-changed event listeners** — Play page and Voices page now listen for the `config-changed` Tauri event and reload config automatically when it changes externally.
+
+### Changed
+
+- **Voice label priority** — `voice_display_name` now prioritizes the profile's `voice_label` from the catalog over the raw `voice_name` from config, giving cleaner filenames in history.
+
+- **Voice label backfill** — Default profile and migration (`migrate_tts_config`) now populate `voice_label` from the voice catalog for profiles that have none.
+
+- **HUD window deferred show** — HUD window starts with `visible: false` in `tauri.conf.json` and explicitly calls `window.show()` in `onMount` after transparent CSS is applied, preventing a white flash.
+
+- **Credential hint uses backend check** — Profile-manager now calls `has_engine_credentials` (covers config + .env) instead of only checking the raw `config.json` api_key field.
+
+### Fixed
+
+- **Play-page reload→save→emit loop** — Added `externalLoad` guard in the config `$effect` to skip auto-save when config was loaded via the `config-changed` event, breaking the infinite reload→save→emit→reload cycle.
+
+- **Footer voice label rendering** — Switched from `||` to `?? null` so legitimately empty-string `voice_label` values are preserved instead of falling through to `voice`.
+
 ### Added
 
 - **Searchable voice picker** — the flat per-engine voice `<Select>` in the profile editor is replaced by `voice-picker.svelte`: a portaled popover with a live search box, automatic grouping (by gender for OpenAI/Google/Cartesia/ElevenLabs, by BCP-47 locale for Edge), inline metadata (`gender · language`) and a check mark on the active voice. Escape / outside-click closes it; the panel flips above the trigger when space below is tight. The manual Voice ID input remains below it as the escape hatch.
@@ -420,7 +444,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SSML support removed** — SSML markup passthrough feature removed
 - **Streaming TTS mode removed** — Simplified to paginated synthesis only
 
-[Unreleased]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.5...v0.1.6

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CopySpeak
 
+**Current Version:** 0.1.9
+
 A modern Windows desktop app that reads clipboard text aloud using AI Text-to-Speech engines. Trigger speech by quickly copying the same text twice in a row.
 
 ## [Download Latest](https://github.com/ilyaizen/CopySpeak/releases)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CopySpeak",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A simple and configurable AI-generated Text-to-Speech (TTS) orchestrator for Windows",
   "type": "module",
   "scripts": {
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@fontsource/lato": "^5.2.7",
-    "@lucide/svelte": "^1.14.0",
+    "@lucide/svelte": "^1.23.0",
     "@tauri-apps/api": "^2.11",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
@@ -39,27 +39,30 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "@internationalized/date": "^3.12.1",
-    "@playwright/test": "^1.60.0",
-    "@rollup/rollup-linux-x64-gnu": "^4.60.3",
+    "@internationalized/date": "^3.12.2",
+    "@playwright/test": "^1.61.1",
+    "@rollup/rollup-linux-x64-gnu": "^4.62.2",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.59.1",
+    "@sveltejs/kit": "^2.69.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@tailwindcss/vite": "^4.3.0",
+    "@tailwindcss/vite": "^4.3.2",
     "@tauri-apps/cli": "^2",
-    "@testing-library/svelte": "^5.3.1",
-    "@types/node": "^25.8.0",
-    "@vitest/ui": "^4.1.6",
+    "@testing-library/svelte": "^5.4.2",
+    "@types/node": "^26.1.0",
+    "@vitest/ui": "^4.1.10",
     "bits-ui": "^2.18.1",
     "jsdom": "^29.1.1",
-    "prettier": "^3.8.3",
-    "prettier-plugin-svelte": "^3.5.2",
+    "prettier": "^3.9.4",
+    "prettier-plugin-svelte": "^4.1.1",
     "prettier-plugin-tailwindcss": "^0.8.0",
-    "svelte": "^5.55.5",
-    "svelte-check": "^4.4.8",
-    "tailwindcss": "^4.3.0",
+    "svelte": "^5.56.4",
+    "svelte-check": "^4.7.1",
+    "tailwindcss": "^4.3.2",
     "typescript": "~6.0.3",
-    "vite": "^8.0.12",
-    "vitest": "^4.1.6"
-  }
+    "vite": "^8.1.3",
+    "vitest": "^4.1.10"
+  },
+  "trustedDependencies": [
+    "es5-ext"
+  ]
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copyspeak"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "CopySpeak - AI text-to-speech orchestrator for Windows"
 

--- a/src-tauri/src/commands/post_process.rs
+++ b/src-tauri/src/commands/post_process.rs
@@ -14,7 +14,10 @@ pub fn check_groq_credentials(
         log::debug!("[IPC] check_groq_credentials called");
     }
 
-    let api_key = config.lock().unwrap().post_process.api_key.clone();
+    let api_key = crate::secrets::resolve(
+        &config.lock().unwrap().post_process.api_key,
+        &["POST_PROCESS_API_KEY"],
+    );
 
     if api_key.trim().is_empty() {
         return Ok(CredentialCheckResult {

--- a/src-tauri/src/commands/tts/credentials.rs
+++ b/src-tauri/src/commands/tts/credentials.rs
@@ -119,6 +119,36 @@ pub fn check_cartesia_credentials(
     }
 }
 
+/// Check whether an engine has credentials available (config.json or .env),
+/// without making any HTTP requests. Used by the UI to hide the "set up
+/// credentials" hint when .env already supplies the key.
+#[tauri::command]
+pub fn has_engine_credentials(engine: String, config: State<'_, Mutex<AppConfig>>) -> bool {
+    let cfg = config.lock().unwrap();
+    match engine.as_str() {
+        "openai" => !crate::secrets::resolve(&cfg.tts.openai.api_key, &["OPENAI_API_KEY"]).is_empty(),
+        "elevenlabs" => {
+            !crate::secrets::resolve(&cfg.tts.elevenlabs.api_key, &["ELEVENLABS_API_KEY"]).is_empty()
+        }
+        "cartesia" => {
+            !crate::secrets::resolve(&cfg.tts.cartesia.api_key, &["CARTESIA_API_KEY"]).is_empty()
+        }
+        "google" => !crate::secrets::resolve(
+            &cfg.tts.google.api_key,
+            &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        )
+        .is_empty(),
+        "microsoft" => {
+            !crate::secrets::resolve(
+                &cfg.tts.microsoft.api_key,
+                &["MICROSOFT_API_KEY", "AZURE_API_KEY"],
+            )
+            .is_empty()
+        }
+        _ => true,
+    }
+}
+
 /// Validate an OpenAI API key via GET /v1/models (no synthesis credits consumed).
 #[tauri::command]
 pub fn check_openai_credentials(

--- a/src-tauri/src/commands/tts/credentials.rs
+++ b/src-tauri/src/commands/tts/credentials.rs
@@ -21,7 +21,10 @@ pub fn check_elevenlabs_credentials(
         log::debug!("[IPC] check_elevenlabs_credentials called");
     }
 
-    let api_key = config.lock().unwrap().tts.elevenlabs.api_key.clone();
+    let api_key = crate::secrets::resolve(
+        &config.lock().unwrap().tts.elevenlabs.api_key,
+        &["ELEVENLABS_API_KEY"],
+    );
 
     if api_key.trim().is_empty() {
         return Ok(CredentialCheckResult {
@@ -71,7 +74,10 @@ pub fn check_cartesia_credentials(
         log::debug!("[IPC] check_cartesia_credentials called");
     }
 
-    let api_key = config.lock().unwrap().tts.cartesia.api_key.clone();
+    let api_key = crate::secrets::resolve(
+        &config.lock().unwrap().tts.cartesia.api_key,
+        &["CARTESIA_API_KEY"],
+    );
 
     if api_key.trim().is_empty() {
         return Ok(CredentialCheckResult {
@@ -122,7 +128,10 @@ pub fn check_openai_credentials(
         log::debug!("[IPC] check_openai_credentials called");
     }
 
-    let api_key = config.lock().unwrap().tts.openai.api_key.clone();
+    let api_key = crate::secrets::resolve(
+        &config.lock().unwrap().tts.openai.api_key,
+        &["OPENAI_API_KEY"],
+    );
 
     if api_key.trim().is_empty() {
         return Ok(CredentialCheckResult {

--- a/src-tauri/src/commands/tts/helpers.rs
+++ b/src-tauri/src/commands/tts/helpers.rs
@@ -270,17 +270,19 @@ pub(crate) fn voice_display_name(
     active: &TtsEngine,
     tts_config: &TtsConfig,
     voice_id: &str,
+    voice_label: Option<&str>,
 ) -> String {
     match active {
         TtsEngine::ElevenLabs => {
-            // Use cached voice_name from config if available
-            tts_config
-                .elevenlabs
-                .voice_name
-                .as_ref()
-                .map(|n| {
-                    // Clean up: extract just the name before " -" or take first word
-                    slugify_filename_part(n)
+            // voice_label from profile catalog takes priority over config/lookup
+            voice_label
+                .map(slugify_filename_part)
+                .or_else(|| {
+                    tts_config
+                        .elevenlabs
+                        .voice_name
+                        .as_ref()
+                        .map(|n| slugify_filename_part(n))
                 })
                 .unwrap_or_else(|| {
                     crate::tts::elevenlabs::ElevenLabsTtsBackend::resolve_voice_name_static(
@@ -289,11 +291,15 @@ pub(crate) fn voice_display_name(
                 })
         }
         TtsEngine::OpenAI => voice_id.to_lowercase(),
-        TtsEngine::Cartesia => tts_config
-            .cartesia
-            .voice_name
-            .as_deref()
+        TtsEngine::Cartesia => voice_label
             .map(slugify_filename_part)
+            .or_else(|| {
+                tts_config
+                    .cartesia
+                    .voice_name
+                    .as_deref()
+                    .map(slugify_filename_part)
+            })
             .unwrap_or_else(|| match voice_id {
                 "f786b574-daa5-4673-aa0c-cbe3e8534c02" => "katie".to_string(),
                 "a5136bf9-224c-4d76-b823-52bd5efcffcc" => "jameson".to_string(),

--- a/src-tauri/src/commands/tts/helpers.rs
+++ b/src-tauri/src/commands/tts/helpers.rs
@@ -227,10 +227,18 @@ pub(crate) fn voice_for_backend(active: &TtsEngine, tts_config: &TtsConfig) -> S
 pub(crate) fn engine_identifier(active: &TtsEngine, tts_config: &TtsConfig) -> String {
     match active {
         TtsEngine::Local => {
-            // Normalize preset names for filenames
-            match tts_config.preset.as_str() {
+            // Preset lives on the active profile's local options now; the
+            // top-level tts_config.preset is a legacy field that's empty for
+            // profile-based configs (would yield a leading-dash filename).
+            let preset = resolve_effective(tts_config)
+                .engine_options
+                .local()
+                .and_then(|o| o.preset.clone())
+                .unwrap_or_else(|| tts_config.preset.trim().to_string());
+            match preset.as_str() {
                 "kokoro-tts" => "kokoro".to_string(),
                 "pocket-tts" => "pocket".to_string(),
+                "" => "local".to_string(),
                 p => p.to_string(),
             }
         }

--- a/src-tauri/src/commands/tts/synthesis.rs
+++ b/src-tauri/src/commands/tts/synthesis.rs
@@ -383,6 +383,7 @@ async fn speak_now_internal(
         &tts_config,
         backend_arc,
         synthesis_ms,
+        eff.voice_label.as_deref(),
     )
 }
 
@@ -542,11 +543,12 @@ fn handle_playback_output(
     tts_config: &crate::config::TtsConfig,
     backend_arc: Arc<Box<dyn TtsBackend>>,
     synthesis_ms: u64,
+    voice_label: Option<&str>,
 ) -> Result<(), String> {
     let envelope = extract_envelope_or_default(wav_bytes);
 
     let engine_id = engine_identifier(active_backend, tts_config);
-    let voice_name = voice_display_name(active_backend, tts_config, voice);
+    let voice_name = voice_display_name(active_backend, tts_config, voice, voice_label);
     let audio_ext = backend_arc.file_extension().to_string();
 
     let history_path =
@@ -786,7 +788,7 @@ pub async fn speak_queued(
 
         // Save to history
         let audio_ext = backend_arc.file_extension().to_string();
-        let voice_name = voice_display_name(&active_backend, &tts_config, &voice);
+        let voice_name = voice_display_name(&active_backend, &tts_config, &voice, eff.voice_label.as_deref());
         let history_path =
             save_to_history_storage(&config, &wav_bytes, &engine_id_val, &voice_name, &audio_ext);
 
@@ -893,7 +895,7 @@ pub async fn speak_history_entry(
     let voice = original_voice;
     let engine_str_val = engine_str(&active_backend);
     let engine_id = engine_identifier(&active_backend, &tts_config);
-    let voice_name = voice_display_name(&active_backend, &tts_config, &voice);
+    let voice_name = voice_display_name(&active_backend, &tts_config, &voice, None);
     let audio_ext = backend.file_extension().to_string();
 
     // Get telemetry estimate

--- a/src-tauri/src/commands/tts/voices.rs
+++ b/src-tauri/src/commands/tts/voices.rs
@@ -32,11 +32,39 @@ pub fn list_tts_voices(
                                 .and_then(|language| language.as_str().map(str::to_string))
                         }),
                         description: voice.description,
+                        gender: voice.labels.as_ref().and_then(|labels| {
+                            labels
+                                .get("gender")
+                                .and_then(|gender| gender.as_str().map(str::to_string))
+                        }),
                         preview_url: voice.preview_url,
                     })
                     .collect()
             })
             .map_err(|e| format!("Failed to fetch voices: {}", e));
+    }
+
+    if engine == TtsEngine::Cartesia {
+        let cfg = config.lock().unwrap();
+        let backend =
+            crate::tts::cartesia::CartesiaTtsBackend::new(cfg.tts.cartesia.clone());
+        return match backend.list_voices() {
+            Ok(voices) => Ok(voices
+                .into_iter()
+                .map(|v| crate::tts::catalog::VoiceCatalogEntry {
+                    id: v.id,
+                    label: v.name.unwrap_or_else(|| "Unnamed voice".into()),
+                    language: None,
+                    description: v.description,
+                    gender: None,
+                    preview_url: None,
+                })
+                .collect()),
+            Err(e) => {
+                log::warn!("Cartesia voice refresh failed, using static list: {}", e);
+                Ok(crate::tts::catalog::list_static_voices(&engine))
+            }
+        };
     }
 
     Ok(crate::tts::catalog::list_static_voices(&engine))

--- a/src-tauri/src/config/tts.rs
+++ b/src-tauri/src/config/tts.rs
@@ -725,13 +725,14 @@ impl Default for VoiceProfile {
     fn default() -> Self {
         let engine = TtsEngine::Edge;
         let voice = "en-US-AvaMultilingualNeural".to_string();
+        let voice_label = catalog_voice_label(&engine, &voice);
         Self {
             id: "default".into(),
             name: "Edge-TTS".into(),
             description: None,
             engine,
             voice,
-            voice_label: None,
+            voice_label,
             speed: 1.0,
             pitch: 1.0,
             effects: ProfileEffects::default(),
@@ -891,6 +892,12 @@ pub fn migrate_tts_config(mut tts: TtsConfig) -> TtsConfig {
                     }
                 }
             }
+        }
+    }
+    // Backfill voice_label from catalog for any profile that has none.
+    for profile in &mut tts.profiles {
+        if profile.voice_label.is_none() {
+            profile.voice_label = catalog_voice_label(&profile.engine, &profile.voice);
         }
     }
     tts.schema_version = 2;

--- a/src-tauri/src/hud.rs
+++ b/src-tauri/src/hud.rs
@@ -78,12 +78,12 @@ pub struct HudPlaybackStartPayload {
     pub audio_duration_ms: Option<u64>,
 }
 
-pub fn get_available_monitors(window: &WebviewWindow) -> Vec<MonitorInfo> {
-    let primary_monitor = window.primary_monitor().ok().flatten();
+pub fn get_available_monitors(app: &AppHandle) -> Vec<MonitorInfo> {
+    let primary_monitor = app.primary_monitor().ok().flatten();
 
     let primary_name = primary_monitor.as_ref().and_then(|m| m.name().cloned());
 
-    match window.available_monitors() {
+    match app.available_monitors() {
         Ok(monitors) => monitors
             .into_iter()
             .map(|m| monitor_to_info(&m, &primary_name))
@@ -115,8 +115,8 @@ fn monitor_to_info(monitor: &Monitor, primary_name: &Option<String>) -> MonitorI
 }
 
 /// Position the HUD window according to config.
-pub fn position_hud_window(hud_window: &WebviewWindow, config: &HudConfig) {
-    let available_monitors = get_available_monitors(hud_window);
+pub fn position_hud_window(app: &AppHandle, hud_window: &WebviewWindow, config: &HudConfig) {
+    let available_monitors = get_available_monitors(app);
 
     let target_monitor = available_monitors
         .iter()
@@ -147,13 +147,21 @@ pub fn position_hud_window(hud_window: &WebviewWindow, config: &HudConfig) {
         monitor_size,
         monitor_offset,
     ) {
-        log::debug!("Setting HUD position to ({}, {})", position.x, position.y);
+        log::info!("[HUD] positioning to ({}, {})", position.x, position.y);
         if let Err(e) = hud_window.set_position(position) {
             log::error!("Failed to set HUD position: {}", e);
+        } else if let Ok(actual) = hud_window.outer_position() {
+            log::info!("[HUD] actual outer position: ({}, {})", actual.x, actual.y);
         }
     } else {
         log::warn!("Failed to compute HUD position, using default");
     }
+}
+
+// ponytail: HUD stays visible always; "hidden" = parked off-screen. Avoids the WebView2
+// transparent-window hidden→visible repaint bug; show_* repositions on-screen.
+pub fn move_hud_offscreen(window: &WebviewWindow) {
+    let _ = window.set_position(PhysicalPosition::new(-10_000, -10_000));
 }
 
 pub fn show_hud(app: &AppHandle, envelope: AmplitudeEnvelope, text: Option<String>) {
@@ -171,11 +179,9 @@ pub fn show_hud(app: &AppHandle, envelope: AmplitudeEnvelope, text: Option<Strin
 
     log::info!("Showing HUD for playback");
 
-    // Show window before emitting event
     if let Some(window) = app.get_webview_window("hud") {
-        if let Err(e) = window.show() {
-            log::error!("Failed to show HUD window: {}", e);
-        }
+        position_hud_window(app, &window, &config);
+        let _ = window.set_ignore_cursor_events(true);
     } else {
         log::warn!("HUD window not found");
     }
@@ -223,11 +229,9 @@ pub fn show_hud_synthesizing(app: &AppHandle, text: Option<String>) {
 
     log::info!("Showing HUD for synthesizing");
 
-    // Show window before emitting event
     if let Some(window) = app.get_webview_window("hud") {
-        if let Err(e) = window.show() {
-            log::error!("Failed to show HUD window: {}", e);
-        }
+        position_hud_window(app, &window, &config);
+        let _ = window.set_ignore_cursor_events(true);
     } else {
         log::warn!("HUD window not found");
     }
@@ -270,11 +274,9 @@ pub fn show_hud_playback(app: &AppHandle, text: Option<String>, audio_duration_m
 
     log::info!("Showing HUD for playback");
 
-    // Show window before emitting event
     if let Some(window) = app.get_webview_window("hud") {
-        if let Err(e) = window.show() {
-            log::error!("Failed to show HUD window: {}", e);
-        }
+        position_hud_window(app, &window, &config);
+        let _ = window.set_ignore_cursor_events(true);
     } else {
         log::warn!("HUD window not found");
     }
@@ -368,11 +370,9 @@ pub fn show_hud_clipboard_copied(app: &AppHandle, trigger_window_ms: u64) {
         return;
     }
 
-    // Show window before emitting event
     if let Some(window) = app.get_webview_window("hud") {
-        if let Err(e) = window.show() {
-            log::error!("Failed to show HUD window: {}", e);
-        }
+        position_hud_window(app, &window, &config);
+        let _ = window.set_ignore_cursor_events(true);
     } else {
         log::warn!("HUD window not found");
     }
@@ -389,11 +389,8 @@ pub fn hide_hud(app: &AppHandle) {
     log::debug!("Hiding HUD");
     let _ = app.emit("hud:stop", ());
 
-    // Hide the window
     if let Some(window) = app.get_webview_window("hud") {
-        if let Err(e) = window.hide() {
-            log::error!("Failed to hide HUD window: {}", e);
-        }
+        move_hud_offscreen(&window);
     }
 }
 
@@ -445,3 +442,5 @@ fn compute_hud_position(
 
     Some(PhysicalPosition::new(x, y))
 }
+
+

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -649,6 +649,7 @@ fn main() {
             commands::check_elevenlabs_credentials,
             commands::check_cartesia_credentials,
             commands::check_openai_credentials,
+            commands::has_engine_credentials,
             commands::check_groq_credentials,
             commands::list_elevenlabs_voices,
             commands::get_elevenlabs_voice_by_id,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,6 +17,7 @@ mod logging;
 mod pagination;
 mod post_process;
 mod sanitize;
+mod secrets;
 mod telemetry;
 mod tts;
 
@@ -269,6 +270,9 @@ fn main() {
         eprintln!("Failed to initialize logging: {}", e);
     }
 
+    // Load .env (next to copyspeak.exe) before any backend reads credentials.
+    secrets::load_dotenv();
+
     tauri::Builder::default()
         .setup(|app| {
             // --- Load config ---
@@ -484,13 +488,19 @@ fn main() {
             }
 
             // --- Position HUD window and make it click-through at startup ---
+            // ponytail: HUD stays visible but parked off-screen; show_* repositions on-screen.
+            // Avoids the WebView2 transparent-window hidden→visible repaint bug.
             if let Some(hud_window) = app.get_webview_window("hud") {
-                let cfg_state = app.state::<std::sync::Mutex<config::AppConfig>>();
-                let cfg = cfg_state.lock().unwrap();
-                hud::position_hud_window(&hud_window, &cfg.hud);
-                drop(cfg);
+                // DON'T move off-screen here — WebView2 controller init is async and fails
+                // if the window is off-screen when the controller finishes creating.
+                // The window is visually invisible anyway (transparent + opacity:0).
                 let _ = hud_window.set_ignore_cursor_events(true);
+                // Refocus main window (HUD no longer has focus:false so it briefly stole focus)
+                if let Some(main_window) = app.get_webview_window("main") {
+                    let _ = main_window.set_focus();
+                }
             }
+
 
             // --- Start local control server for trusted localhost integrations (Pi, etc.) ---
             control_server::start(app.handle().clone());

--- a/src-tauri/src/post_process/mod.rs
+++ b/src-tauri/src/post_process/mod.rs
@@ -41,7 +41,8 @@ struct ResponseMessage {
 /// success. Caller is responsible for the fallback — this never silently
 /// returns the original.
 pub async fn process(text: &str, cfg: &PostProcessConfig) -> Result<String, String> {
-    if cfg.api_key.trim().is_empty() {
+    let api_key = crate::secrets::resolve(&cfg.api_key, &["POST_PROCESS_API_KEY"]);
+    if api_key.trim().is_empty() {
         return Err("Groq API key is empty".into());
     }
     if cfg.model.trim().is_empty() {
@@ -65,7 +66,7 @@ pub async fn process(text: &str, cfg: &PostProcessConfig) -> Result<String, Stri
     let url = format!("{}/chat/completions", GROQ_BASE_URL);
     let resp = client
         .post(&url)
-        .bearer_auth(&cfg.api_key)
+        .bearer_auth(&api_key)
         .json(&req)
         .send()
         .await

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1,0 +1,62 @@
+// Secret resolution: overlay a .env file (next to the executable) on top of
+// config.json values. Env wins when set & non-empty; config.json stays the
+// fallback for keys typed in the UI. Env values are never written back to disk
+// (config.json is serialized from its own fields, not the resolved values).
+
+use std::path::PathBuf;
+
+/// Load `<exe-dir>/.env` into the process environment at startup.
+/// Format: `KEY=VALUE` per line; blank and `#`-prefixed lines are ignored.
+// ponytail: naive parser, no quotes/escapes/export — API tokens are simple
+// tokens. Swap to dotenvy if the file ever needs shell-style quoting.
+pub fn load_dotenv() {
+    let Some(dir) = exe_dir() else {
+        return;
+    };
+    let path = dir.join(".env");
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return;
+    };
+
+    let mut count = 0;
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            log::warn!("[secrets] skipping malformed .env line: {line}");
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        std::env::set_var(key, value.trim());
+        count += 1;
+    }
+    if count > 0 {
+        log::info!("[secrets] loaded {count} var(s) from {}", path.display());
+    }
+}
+
+/// Resolve a credential: first non-empty value among the named env vars wins,
+/// otherwise fall back to the config.json value. Returned values are trimmed.
+pub fn resolve(config_val: &str, env_names: &[&str]) -> String {
+    for name in env_names {
+        if let Ok(v) = std::env::var(name) {
+            let v = v.trim();
+            if !v.is_empty() {
+                return v.to_string();
+            }
+        }
+    }
+    config_val.trim().to_string()
+}
+
+/// Directory containing the running executable — the .env lookup root.
+// ponytail: single location (next to copyspeak.exe) per design; in dev the exe
+// is target/debug/copyspeak.exe, so drop .env there for `cargo tauri dev`.
+fn exe_dir() -> Option<PathBuf> {
+    std::env::current_exe().ok()?.parent().map(PathBuf::from)
+}

--- a/src-tauri/src/tts/cartesia.rs
+++ b/src-tauri/src/tts/cartesia.rs
@@ -1,10 +1,30 @@
 use super::{TtsBackend, TtsError};
 use crate::config::CartesiaConfig;
 use reqwest::Client;
+use serde::Deserialize;
 use serde_json::json;
 
 const CARTESIA_TTS_URL: &str = "https://api.cartesia.ai/tts/bytes";
 const CARTESIA_VERSION: &str = "2024-06-10";
+
+/// Voice metadata from the Cartesia `/voices` API.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct CartesiaVoice {
+    pub id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+}
+
+impl Default for CartesiaVoice {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: None,
+            description: None,
+        }
+    }
+}
 
 pub struct CartesiaTtsBackend {
     config: CartesiaConfig,
@@ -26,6 +46,44 @@ impl CartesiaTtsBackend {
                 rt.block_on(f)
             }
         }
+    }
+
+    /// Fetch available voices from the Cartesia API.
+    /// GET https://api.cartesia.ai/voices — returns the account's voice library.
+    /// On failure the caller falls back to the static catalog list.
+    pub fn list_voices(&self) -> Result<Vec<CartesiaVoice>, TtsError> {
+        let api_key = crate::secrets::resolve(&self.config.api_key, &["CARTESIA_API_KEY"]);
+        if api_key.trim().is_empty() {
+            return Err(TtsError::Unavailable("Cartesia API key is missing".into()));
+        }
+        let (status, body) = Self::block_on_async(async move {
+            let client = Client::new();
+            let response = client
+                .get("https://api.cartesia.ai/voices")
+                .header("X-API-Key", api_key)
+                .header("Cartesia-Version", CARTESIA_VERSION)
+                .header("Accept", "application/json")
+                .send()
+                .await
+                .map_err(|e| TtsError::Http(format!("Failed to fetch voices: {}", e)))?;
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .map_err(|e| TtsError::Http(format!("Failed to read voices response: {}", e)))?;
+            Ok::<_, TtsError>((status, body))
+        })?;
+
+        if !status.is_success() {
+            return Err(TtsError::Http(format!(
+                "Cartesia API error {}: {}",
+                status,
+                body.chars().take(300).collect::<String>()
+            )));
+        }
+
+        serde_json::from_str::<Vec<CartesiaVoice>>(&body)
+            .map_err(|e| TtsError::Http(format!("Failed to parse voices response: {}", e)))
     }
 }
 
@@ -57,7 +115,7 @@ impl TtsBackend for CartesiaTtsBackend {
         );
 
         let start_time = std::time::Instant::now();
-        let api_key = self.config.api_key.clone();
+        let api_key = crate::secrets::resolve(&self.config.api_key, &["CARTESIA_API_KEY"]);
 
         let response = Self::block_on_async(async {
             let client = Client::new();
@@ -110,7 +168,10 @@ impl TtsBackend for CartesiaTtsBackend {
     }
 
     fn health_check(&self) -> Result<(), TtsError> {
-        if self.config.api_key.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.api_key, &["CARTESIA_API_KEY"])
+            .trim()
+            .is_empty()
+        {
             return Err(TtsError::Unavailable("Cartesia API key is missing".into()));
         }
         Ok(())

--- a/src-tauri/src/tts/catalog.rs
+++ b/src-tauri/src/tts/catalog.rs
@@ -40,6 +40,7 @@ pub struct VoiceCatalogEntry {
     pub label: String,
     pub language: Option<String>,
     pub description: Option<String>,
+    pub gender: Option<String>,
     pub preview_url: Option<String>,
 }
 
@@ -64,12 +65,14 @@ fn voice(
     label: &str,
     language: Option<&str>,
     description: Option<&str>,
+    gender: Option<&str>,
 ) -> VoiceCatalogEntry {
     VoiceCatalogEntry {
         id: id.into(),
         label: label.into(),
         language: language.map(str::to_string),
         description: description.map(str::to_string),
+        gender: gender.map(str::to_string),
         preview_url: None,
     }
 }
@@ -112,6 +115,7 @@ pub fn list_engines() -> Vec<EngineCatalogEntry> {
                 "Rosie",
                 Some("en"),
                 Some("KittenTTS fallback voice"),
+                None,
             )],
         },
         EngineCatalogEntry {
@@ -192,13 +196,19 @@ pub fn list_engines() -> Vec<EngineCatalogEntry> {
                     serde_json::json!(null),
                 ),
             ],
-            voices: [
-                "alloy", "ash", "ballad", "coral", "echo", "fable", "nova", "onyx", "sage",
-                "shimmer", "verse",
-            ]
-            .iter()
-            .map(|v| voice(v, v, Some("en"), None))
-            .collect(),
+            voices: vec![
+                voice("alloy", "Alloy", Some("en"), Some("Warm, neutral all-rounder"), Some("female")),
+                voice("ash", "Ash", Some("en"), Some("Calm and conversational"), Some("male")),
+                voice("ballad", "Ballad", Some("en"), Some("Singing-leaning, expressive"), Some("male")),
+                voice("coral", "Coral", Some("en"), Some("Warm and confident"), Some("female")),
+                voice("echo", "Echo", Some("en"), Some("Calm and measured"), Some("male")),
+                voice("fable", "Fable", Some("en"), Some("British and expressive"), Some("male")),
+                voice("nova", "Nova", Some("en"), Some("Bright and energetic"), Some("female")),
+                voice("onyx", "Onyx", Some("en"), Some("Deep and authoritative"), Some("male")),
+                voice("sage", "Sage", Some("en"), Some("Calm and introspective"), Some("female")),
+                voice("shimmer", "Shimmer", Some("en"), Some("Soft and airy"), Some("female")),
+                voice("verse", "Verse", Some("en"), Some("Neutral and steady"), Some("male")),
+            ],
         },
         EngineCatalogEntry {
             engine: TtsEngine::ElevenLabs,
@@ -252,19 +262,38 @@ pub fn list_engines() -> Vec<EngineCatalogEntry> {
                     serde_json::json!(null),
                 ),
             ],
-            voices: vec![voice(
-                "21m00Tcm4TlvDq8ikWAM",
-                "Rachel",
-                Some("en"),
-                Some("Premade fallback voice"),
-            )],
+            voices: vec![
+                // 21 premade voices — fetched from GET /v1/voices (2026-07-06).
+                // ponytail: static snapshot; refresh button hits the live API for the full set.
+                voice("pNInz6obpgDQGcFmaJgB", "Adam", None, Some("American · male · Dominant, Firm"), Some("male")),
+                voice("Xb7hH8MSUJpSbSDYk0k2", "Alice", None, Some("British · female · Clear, Engaging Educator"), Some("female")),
+                voice("hpp4J3VqNfWAUOO0d1Us", "Bella", None, Some("American · female · Professional, Bright, Warm"), Some("female")),
+                voice("pqHfZKP75CvOlQylNhV4", "Bill", None, Some("American · male · Wise, Mature, Balanced"), Some("male")),
+                voice("nPczCjzI2devNBz1zQrb", "Brian", None, Some("American · male · Deep, Resonant and Comforting"), Some("male")),
+                voice("N2lVS1w4EtoT3dr4eOWO", "Callum", None, Some("American · male · Husky Trickster"), Some("male")),
+                voice("IKne3meq5aSn9XLyUdCD", "Charlie", None, Some("Australian · male · Deep, Confident, Energetic"), Some("male")),
+                voice("iP95p4xoKVk53GoZ742B", "Chris", None, Some("American · male · Charming, Down-to-Earth"), Some("male")),
+                voice("onwK4e9ZLuTAKqWW03F9", "Daniel", None, Some("British · male · Steady Broadcaster"), Some("male")),
+                voice("cjVigY5qzO86Huf0OWal", "Eric", None, Some("American · male · Smooth, Trustworthy"), Some("male")),
+                voice("JBFqnCBsd6RMkjVDRZzb", "George", None, Some("British · male · Warm, Captivating Storyteller"), Some("male")),
+                voice("SOYHLrjzK2X1ezoPC6cr", "Harry", None, Some("American · male · Fierce Warrior"), Some("male")),
+                voice("cgSgspJ2msm6clMCkdW9", "Jessica", None, Some("American · female · Playful, Bright, Warm"), Some("female")),
+                voice("FGY2WhTYpPnrIDTdsKH5", "Laura", None, Some("American · female · Enthusiast, Quirky Attitude"), Some("female")),
+                voice("TX3LPaxmHKxFdv7VOQHJ", "Liam", None, Some("American · male · Energetic, Social Media Creator"), Some("male")),
+                voice("pFZP5JQG7iQjIQuC4Bku", "Lily", None, Some("British · female · Velvety Actress"), Some("female")),
+                voice("XrExE9yKIg1WjnnlVkGX", "Matilda", None, Some("American · female · Knowledgable, Professional"), Some("female")),
+                voice("SAz9YHcvj6GT2YYXdXww", "River", None, Some("American · neutral · Relaxed, Neutral, Informative"), Some("neutral")),
+                voice("CwhRBWXzGAHq8TQ4Fs17", "Roger", None, Some("American · male · Laid-Back, Casual, Resonant"), Some("male")),
+                voice("EXAVITQu4vr4xnSDxMaL", "Sarah", None, Some("American · female · Mature, Reassuring, Confident"), Some("female")),
+                voice("bIHbv24MWmeRgasZH58o", "Will", None, Some("American · male · Relaxed Optimist"), Some("male")),
+            ],
         },
         EngineCatalogEntry {
             engine: TtsEngine::Cartesia,
             label: "Cartesia".into(),
             description: "Cartesia Sonic TTS.".into(),
             docs_url: "https://docs.cartesia.ai/api-reference/tts/bytes".into(),
-            supports_voice_refresh: false,
+            supports_voice_refresh: true,
             supports_pitch: false,
             supports_bracket_emotes: false,
             options: vec![
@@ -301,14 +330,16 @@ pub fn list_engines() -> Vec<EngineCatalogEntry> {
                 voice(
                     "f786b574-daa5-4673-aa0c-cbe3e8534c02",
                     "Katie",
-                    Some("en"),
                     None,
+                    Some("Warm, friendly default"),
+                    Some("female"),
                 ),
                 voice(
                     "a5136bf9-224c-4d76-b823-52bd5efcffcc",
                     "Jameson",
-                    Some("en"),
                     None,
+                    Some("Calm, deep default"),
+                    Some("male"),
                 ),
             ],
         },
@@ -336,40 +367,37 @@ pub fn list_engines() -> Vec<EngineCatalogEntry> {
                     serde_json::json!("wav"),
                 ),
             ],
-            voices: [
-                "Kore",
-                "Puck",
-                "Charon",
-                "Fenrir",
-                "Leda",
-                "Orus",
-                "Aoede",
-                "Callirrhoe",
-                "Autonoe",
-                "Enceladus",
-                "Iapetus",
-                "Umbriel",
-                "Algieba",
-                "Despina",
-                "Erinome",
-                "Algenib",
-                "Rasalgethi",
-                "Laomedeia",
-                "Achernar",
-                "Alnilam",
-                "Schedar",
-                "Gacrux",
-                "Pulcherrima",
-                "Achird",
-                "Zubenelgenubi",
-                "Vindemiatrix",
-                "Sadachbia",
-                "Sadaltager",
-                "Sulafat",
-            ]
-            .iter()
-            .map(|v| voice(v, v, None, None))
-            .collect(),
+            voices: vec![
+                voice("Kore", "Kore", None, Some("Upbeat"), Some("female")),
+                voice("Puck", "Puck", None, Some("Upbeat"), Some("male")),
+                voice("Charon", "Charon", None, Some("Informative"), Some("male")),
+                voice("Fenrir", "Fenrir", None, Some("Breezy, casual"), Some("male")),
+                voice("Leda", "Leda", None, Some("Youthful"), Some("female")),
+                voice("Orus", "Orus", None, Some("Firm, industrial"), Some("male")),
+                voice("Aoede", "Aoede", None, Some("Soft, dreamy"), Some("female")),
+                voice("Callirrhoe", "Callirrhoe", None, Some("Girl, youthful"), Some("female")),
+                voice("Autonoe", "Autonoe", None, Some("Breezy"), Some("female")),
+                voice("Enceladus", "Enceladus", None, Some("Breezy"), Some("male")),
+                voice("Iapetus", "Iapetus", None, Some("Clear, professional"), Some("male")),
+                voice("Umbriel", "Umbriel", None, Some("Easygoing"), Some("male")),
+                voice("Algieba", "Algieba", None, Some("Casual, relaxed"), Some("female")),
+                voice("Despina", "Despina", None, Some("Youthful"), Some("female")),
+                voice("Erinome", "Erinome", None, Some("Calm"), Some("female")),
+                voice("Algenib", "Algenib", None, Some("Sturdy"), Some("male")),
+                voice("Rasalgethi", "Rasalgethi", None, Some("Informative"), Some("male")),
+                voice("Laomedeia", "Laomedeia", None, Some("Upbeat"), Some("female")),
+                voice("Achernar", "Achernar", None, Some("Soft, low"), Some("male")),
+                voice("Alnilam", "Alnilam", None, Some("Firm"), Some("male")),
+                voice("Schedar", "Schedar", None, Some("Casual"), Some("female")),
+                voice("Gacrux", "Gacrux", None, Some("Maternal"), Some("female")),
+                voice("Pulcherrima", "Pulcherrima", None, Some("Soft, forward"), Some("female")),
+                voice("Achird", "Achird", None, Some("Relaxed, easygoing"), Some("male")),
+                voice("Zubenelgenubi", "Zubenelgenubi", None, Some("Casual, laid-back"), Some("male")),
+                voice("Vindemiatrix", "Vindemiatrix", None, Some("Gentle"), Some("female")),
+                voice("Sadachbia", "Sadachbia", None, Some("Lively, breezy"), Some("male")),
+                voice("Sadaltager", "Sadaltager", None, Some("Knowledgeable, warm"), Some("male")),
+                voice("Sulafat", "Sulafat", None, Some("Warm"), Some("female")),
+            ],
         },
         EngineCatalogEntry {
             engine: TtsEngine::Microsoft,
@@ -417,44 +445,54 @@ pub fn list_engines() -> Vec<EngineCatalogEntry> {
             supports_bracket_emotes: false,
             options: vec![],
             voices: [
+                // Genders sourced from `edge-tts --list-voices` (Microsoft's own
+                // readaloud metadata), lowercased to match the cloud engines.
                 // ── US ──────────────────────────────────────────
-                ("en-US-AvaMultilingualNeural", "Ava, Multilingual"),
-                ("en-US-EmmaMultilingualNeural", "Emma, Multilingual"),
-                ("en-US-AndrewMultilingualNeural", "Andrew, Multilingual"),
-                ("en-US-BrianMultilingualNeural", "Brian, Multilingual"),
-                ("en-US-AriaNeural", "Aria"),
-                ("en-US-JennyNeural", "Jenny"),
-                ("en-US-GuyNeural", "Guy"),
-                ("en-US-DavisNeural", "Davis"),
-                ("en-US-AmberNeural", "Amber"),
-                ("en-US-AnaNeural", "Ana"),
-                ("en-US-AndrewNeural", "Andrew"),
-                ("en-US-AvaNeural", "Ava"),
-                ("en-US-BrianNeural", "Brian"),
-                ("en-US-ChristopherNeural", "Christopher"),
-                ("en-US-EmmaNeural", "Emma"),
-                ("en-US-EricNeural", "Eric"),
-                ("en-US-MichelleNeural", "Michelle"),
-                ("en-US-RogerNeural", "Roger"),
-                ("en-US-SteffanNeural", "Steffan"),
+                ("en-US-AvaMultilingualNeural", "Ava, Multilingual", Some("female")),
+                ("en-US-EmmaMultilingualNeural", "Emma, Multilingual", Some("female")),
+                ("en-US-AndrewMultilingualNeural", "Andrew, Multilingual", Some("male")),
+                ("en-US-BrianMultilingualNeural", "Brian, Multilingual", Some("male")),
+                ("en-US-AriaNeural", "Aria", Some("female")),
+                ("en-US-JennyNeural", "Jenny", Some("female")),
+                ("en-US-GuyNeural", "Guy", Some("male")),
+                // ponytail: Davis & Amber are absent from the live edge-tts list
+                // (likely deprecated by Microsoft); gender unknown → None.
+                ("en-US-DavisNeural", "Davis", None),
+                ("en-US-AmberNeural", "Amber", None),
+                ("en-US-AnaNeural", "Ana", Some("female")),
+                ("en-US-AndrewNeural", "Andrew", Some("male")),
+                ("en-US-AvaNeural", "Ava", Some("female")),
+                ("en-US-BrianNeural", "Brian", Some("male")),
+                ("en-US-ChristopherNeural", "Christopher", Some("male")),
+                ("en-US-EmmaNeural", "Emma", Some("female")),
+                ("en-US-EricNeural", "Eric", Some("male")),
+                ("en-US-MichelleNeural", "Michelle", Some("female")),
+                ("en-US-RogerNeural", "Roger", Some("male")),
+                ("en-US-SteffanNeural", "Steffan", Some("male")),
                 // ── GB ──────────────────────────────────────────
-                ("en-GB-SoniaNeural", "Sonia, United Kingdom"),
-                ("en-GB-RyanNeural", "Ryan, United Kingdom"),
-                ("en-GB-LibbyNeural", "Libby, United Kingdom"),
-                ("en-GB-MaisieNeural", "Maisie, United Kingdom"),
-                ("en-GB-ThomasNeural", "Thomas, United Kingdom"),
+                ("en-GB-SoniaNeural", "Sonia", Some("female")),
+                ("en-GB-RyanNeural", "Ryan", Some("male")),
+                ("en-GB-LibbyNeural", "Libby", Some("female")),
+                ("en-GB-MaisieNeural", "Maisie", Some("female")),
+                ("en-GB-ThomasNeural", "Thomas", Some("male")),
                 // ── AU ──────────────────────────────────────────
-                ("en-AU-NatashaNeural", "Natasha, Australia"),
-                ("en-AU-WilliamMultilingualNeural", "William, Australia, Multilingual"),
+                ("en-AU-NatashaNeural", "Natasha", Some("female")),
+                ("en-AU-WilliamMultilingualNeural", "William, Multilingual", Some("male")),
                 // ── CA ──────────────────────────────────────────
-                ("en-CA-ClaraNeural", "Clara, Canada"),
-                ("en-CA-LiamNeural", "Liam, Canada"),
+                ("en-CA-ClaraNeural", "Clara", Some("female")),
+                ("en-CA-LiamNeural", "Liam", Some("male")),
                 // ── IE ──────────────────────────────────────────
-                ("en-IE-ConnorNeural", "Connor, Ireland"),
-                ("en-IE-EmilyNeural", "Emily, Ireland"),
+                ("en-IE-ConnorNeural", "Connor", Some("male")),
+                ("en-IE-EmilyNeural", "Emily", Some("female")),
             ]
             .iter()
-            .map(|(id, label)| voice(id, label, Some("en"), None))
+            .map(|(id, label, gender)| {
+                // Edge ids encode the BCP-47 locale (en-US, en-GB, …); keep it as
+                // the grouping key so the picker clusters by region, with gender
+                // surfaced as per-row meta (see voice-picker.svelte::useLocale).
+                let locale: String = id.split('-').take(2).collect::<Vec<_>>().join("-");
+                voice(id, label, Some(locale.as_str()), None, *gender)
+            })
             .collect(),
         },
     ]

--- a/src-tauri/src/tts/elevenlabs.rs
+++ b/src-tauri/src/tts/elevenlabs.rs
@@ -222,7 +222,10 @@ impl ElevenLabsTtsBackend {
     pub fn list_voices(&self) -> Result<Vec<ElevenLabsVoice>, TtsError> {
         log::debug!("ElevenLabs - fetching available voices");
 
-        if self.config.api_key.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.api_key, &["ELEVENLABS_API_KEY"])
+            .trim()
+            .is_empty()
+        {
             log::error!("ElevenLabs - API key is missing");
             return Err(TtsError::Unavailable(
                 "ElevenLabs API key is missing".into(),
@@ -245,7 +248,7 @@ impl ElevenLabsTtsBackend {
     /// Internal method to fetch voices from API
     fn list_voices_internal(&self) -> Result<Vec<ElevenLabsVoice>, TtsError> {
         let url = "https://api.elevenlabs.io/v1/voices";
-        let api_key = self.config.api_key.clone();
+        let api_key = crate::secrets::resolve(&self.config.api_key, &["ELEVENLABS_API_KEY"]);
 
         let start_time = std::time::Instant::now();
 
@@ -434,7 +437,10 @@ impl ElevenLabsTtsBackend {
             return Ok(voice.clone());
         }
 
-        if self.config.api_key.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.api_key, &["ELEVENLABS_API_KEY"])
+            .trim()
+            .is_empty()
+        {
             log::error!("ElevenLabs - API key is missing");
             return Err(TtsError::Unavailable(
                 "ElevenLabs API key is missing".into(),
@@ -459,7 +465,7 @@ impl ElevenLabsTtsBackend {
     /// Internal method to fetch a single voice by ID from API
     fn get_voice_by_id_internal(&self, voice_id: &str) -> Result<ElevenLabsVoice, TtsError> {
         let url = format!("https://api.elevenlabs.io/v1/voices/{}", voice_id);
-        let api_key = self.config.api_key.clone();
+        let api_key = crate::secrets::resolve(&self.config.api_key, &["ELEVENLABS_API_KEY"]);
         let voice_id_owned = voice_id.to_string();
 
         let start_time = std::time::Instant::now();
@@ -609,7 +615,7 @@ impl TtsBackend for ElevenLabsTtsBackend {
             );
         }
 
-        let api_key = self.config.api_key.clone();
+        let api_key = crate::secrets::resolve(&self.config.api_key, &["ELEVENLABS_API_KEY"]);
         let mime_type = self.config.output_format.mime_type();
         let output_format = self.config.output_format.as_str();
 
@@ -681,7 +687,10 @@ impl TtsBackend for ElevenLabsTtsBackend {
     fn health_check(&self) -> Result<(), TtsError> {
         log::debug!("ElevenLabs TTS health check - validating API key");
 
-        if self.config.api_key.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.api_key, &["ELEVENLABS_API_KEY"])
+            .trim()
+            .is_empty()
+        {
             log::error!("ElevenLabs TTS health check failed - API key is missing");
             return Err(TtsError::Unavailable(
                 "ElevenLabs API key is missing".into(),

--- a/src-tauri/src/tts/google.rs
+++ b/src-tauri/src/tts/google.rs
@@ -97,7 +97,8 @@ impl TtsBackend for GoogleTtsBackend {
         );
 
         let start_time = std::time::Instant::now();
-        let api_key = self.config.api_key.clone();
+        let api_key =
+            crate::secrets::resolve(&self.config.api_key, &["GEMINI_API_KEY", "GOOGLE_API_KEY"]);
 
         let response = Self::block_on_async(async {
             let client = Client::new();
@@ -159,7 +160,10 @@ impl TtsBackend for GoogleTtsBackend {
     }
 
     fn health_check(&self) -> Result<(), TtsError> {
-        if self.config.api_key.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.api_key, &["GEMINI_API_KEY", "GOOGLE_API_KEY"])
+            .trim()
+            .is_empty()
+        {
             return Err(TtsError::Unavailable("Google API key is missing".into()));
         }
         Ok(())

--- a/src-tauri/src/tts/microsoft.rs
+++ b/src-tauri/src/tts/microsoft.rs
@@ -57,7 +57,13 @@ impl TtsBackend for MicrosoftTtsBackend {
     }
 
     fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>, TtsError> {
-        if self.config.endpoint.trim().is_empty() {
+        let api_key = crate::secrets::resolve(
+            &self.config.api_key,
+            &["MICROSOFT_API_KEY", "AZURE_API_KEY"],
+        );
+        let endpoint = crate::secrets::resolve(&self.config.endpoint, &["MICROSOFT_ENDPOINT"]);
+
+        if endpoint.trim().is_empty() {
             return Err(TtsError::Unavailable(
                 "Microsoft endpoint is not configured".into(),
             ));
@@ -78,8 +84,6 @@ impl TtsBackend for MicrosoftTtsBackend {
         );
 
         let start_time = std::time::Instant::now();
-        let api_key = self.config.api_key.clone();
-        let endpoint = self.config.endpoint.clone();
 
         let response = Self::block_on_async(async {
             let client = Client::new();
@@ -140,10 +144,16 @@ impl TtsBackend for MicrosoftTtsBackend {
     }
 
     fn health_check(&self) -> Result<(), TtsError> {
-        if self.config.api_key.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.api_key, &["MICROSOFT_API_KEY", "AZURE_API_KEY"])
+            .trim()
+            .is_empty()
+        {
             return Err(TtsError::Unavailable("Microsoft API key is missing".into()));
         }
-        if self.config.endpoint.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.endpoint, &["MICROSOFT_ENDPOINT"])
+            .trim()
+            .is_empty()
+        {
             return Err(TtsError::Unavailable(
                 "Microsoft endpoint is missing".into(),
             ));

--- a/src-tauri/src/tts/openai.rs
+++ b/src-tauri/src/tts/openai.rs
@@ -56,7 +56,7 @@ impl TtsBackend for OpenAiTtsBackend {
             body["instructions"] = json!(instructions);
         }
 
-        let api_key = self.config.api_key.clone();
+        let api_key = crate::secrets::resolve(&self.config.api_key, &["OPENAI_API_KEY"]);
 
         // Log request details
         log::info!(
@@ -128,7 +128,10 @@ impl TtsBackend for OpenAiTtsBackend {
     fn health_check(&self) -> Result<(), TtsError> {
         log::debug!("OpenAI TTS health check - validating API key");
 
-        if self.config.api_key.trim().is_empty() {
+        if crate::secrets::resolve(&self.config.api_key, &["OPENAI_API_KEY"])
+            .trim()
+            .is_empty()
+        {
             log::error!("OpenAI TTS health check failed - API key is missing");
             return Err(TtsError::Unavailable("OpenAI API key is missing".into()));
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,7 +62,7 @@
         "alwaysOnTop": true,
         "resizable": false,
         "skipTaskbar": true,
-        "visible": true
+        "visible": false
       }
     ]
   },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,6 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
-  "productName": "CopySpeak",
-  "version": "0.1.8",
+  "productName": "copyspeak",
+  "version": "0.1.9",
   "identifier": "com.copyspeak.tts",
   "build": {
     "frontendDist": "../dist",
@@ -48,9 +47,7 @@
         "resizable": false,
         "center": true,
         "visible": true,
-        "devtools": true,
-        "additionalBrowserArgs": "--force-prefers-no-reduced-motion --enable-smooth-scrolling --allow-file-access-from-files --allow-universal-access-from-files --disable-features=VizDisplayCompositor"
-
+        "devtools": true
       },
       {
         "label": "hud",
@@ -65,8 +62,7 @@
         "alwaysOnTop": true,
         "resizable": false,
         "skipTaskbar": true,
-        "visible": false,
-        "focus": false
+        "visible": true
       }
     ]
   },

--- a/src/lib/components/engine/profile-manager.svelte
+++ b/src/lib/components/engine/profile-manager.svelte
@@ -10,12 +10,12 @@
     Trash2,
     Download,
     Upload,
-    RefreshCw,
     ExternalLink,
     AlertTriangle
   } from "@lucide/svelte";
   import { toast } from "svelte-sonner";
   import ProfileExportDialog from "./profile-export-dialog.svelte";
+  import VoicePicker from "./voice-picker.svelte";
   import { findSetupEntry } from "./engine-meta";
   import type {
     AppConfig,
@@ -71,12 +71,6 @@
   );
   const activeVoiceCatalog = $derived<VoiceCatalogEntry[]>(
     active ? catalogVoicesFor(active.engine as TtsEngine) : []
-  );
-  const activeVoiceOptions = $derived(
-    activeVoiceCatalog.map((voice: VoiceCatalogEntry) => ({
-      value: voice.id,
-      label: voice.label
-    }))
   );
 
   // Passive hint: the active profile's engine needs a credential that isn't set.
@@ -318,36 +312,19 @@
           </div>
         </SettingRow>
 
-        {#if activeVoiceOptions.length > 0}
-          <SettingRow label="Voice" tooltip="Known voices from the engine catalog or provider API.">
-            <div class="flex w-56 gap-1.5">
-              <Select
-                options={activeVoiceOptions}
-                value={active.voice}
-                onchange={(e) => setVoice(activeIndex, (e.target as HTMLSelectElement).value)}
-                class="min-w-0 flex-1"
-              />
-              <Button
-                variant="outline"
-                size="sm"
-                onclick={() => refreshVoices(active.engine)}
-                disabled={voicesLoadingFor === active.engine}
-                title="Refresh voices"
-              >
-                <RefreshCw size={14} />
-              </Button>
-            </div>
-          </SettingRow>
-        {:else if activeCatalogEntry?.supports_voice_refresh}
-          <SettingRow label="Voice">
-            <Button
-              variant="outline"
-              size="sm"
-              onclick={() => refreshVoices(active.engine)}
-              disabled={voicesLoadingFor === active.engine}
-            >
-              {voicesLoadingFor === active.engine ? "Loading voices…" : "Load voices"}
-            </Button>
+        {#if activeVoiceCatalog.length > 0 || activeCatalogEntry?.supports_voice_refresh}
+          <SettingRow
+            label="Voice"
+            tooltip="Known voices from the engine catalog or provider API."
+          >
+            <VoicePicker
+              voices={activeVoiceCatalog}
+              value={active.voice}
+              loading={voicesLoadingFor === active.engine}
+              supportsRefresh={!!activeCatalogEntry?.supports_voice_refresh}
+              onselect={(id) => setVoice(activeIndex, id)}
+              onrefresh={() => refreshVoices(active.engine)}
+            />
           </SettingRow>
         {/if}
 

--- a/src/lib/components/engine/profile-manager.svelte
+++ b/src/lib/components/engine/profile-manager.svelte
@@ -73,14 +73,26 @@
     active ? catalogVoicesFor(active.engine as TtsEngine) : []
   );
 
-  // Passive hint: the active profile's engine needs a credential that isn't set.
-  // Cheap local check (no IPC) — points the user to /engines rather than blocking.
+  // Passive hint: checks backend (config.json + .env) for credential presence.
+  let credentialsResolved = $state<Record<string, boolean>>({});
+
+  $effect(() => {
+    if (!active) return;
+    const entry = findSetupEntry(active.engine);
+    if (!entry || !entry.credentialTarget) return;
+    const engine = active.engine;
+    // Skip if already checked
+    if (engine in credentialsResolved) return;
+    invoke<boolean>("has_engine_credentials", { engine }).then((ok) => {
+      credentialsResolved[engine] = ok;
+    });
+  });
+
   const credentialMissing = $derived(() => {
     if (!active) return false;
     const entry = findSetupEntry(active.engine);
     if (!entry || !entry.credentialTarget) return false;
-    const fields = localConfig.tts as unknown as Record<string, { api_key?: string }>;
-    return !fields[entry.credentialTarget]?.api_key;
+    return credentialsResolved[active.engine] === false;
   });
 
   $effect(() => {

--- a/src/lib/components/engine/voice-picker.svelte
+++ b/src/lib/components/engine/voice-picker.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  import { cn, portal } from "$lib/utils.js";
+  import { Check, ChevronDown, RefreshCw, Search } from "@lucide/svelte";
+  import type { VoiceCatalogEntry } from "$lib/types";
+
+  let {
+    voices,
+    value,
+    loading = false,
+    supportsRefresh = false,
+    onselect,
+    onrefresh
+  }: {
+    voices: VoiceCatalogEntry[];
+    value: string;
+    loading?: boolean;
+    supportsRefresh?: boolean;
+    onselect: (id: string) => void;
+    onrefresh?: () => void;
+  } = $props();
+
+  let open = $state(false);
+  let query = $state("");
+  let triggerRef = $state<HTMLButtonElement | null>(null);
+  let panelRef = $state<HTMLDivElement | null>(null);
+  let searchRef = $state<HTMLInputElement | null>(null);
+
+  const selected = $derived(voices.find((v) => v.id === value) ?? null);
+
+  // Grouping priority: region locale (Edge en-US/en-GB/…) wins over gender
+  // (OpenAI/Google/Cartesia/ElevenLabs) — region is the more useful cluster for
+  // Edge, so gender shows as per-row meta instead of becoming the header.
+  const useLocale = $derived(voices.some((v) => (v.language ?? "").includes("-")));
+  const useGender = $derived(!useLocale && voices.some((v) => v.gender));
+  const useLanguage = $derived(!useLocale && !useGender && voices.some((v) => v.language));
+
+  const filtered = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return voices;
+    return voices.filter((v) =>
+      [v.label, v.id, v.gender, v.language, v.description]
+        .filter((s): s is string => Boolean(s))
+        .some((s) => s.toLowerCase().includes(q))
+    );
+  });
+
+  const GROUP_ORDER: Record<string, number> = { Female: 0, Male: 1 };
+
+  const groups = $derived.by(() => {
+    const map = new Map<string, VoiceCatalogEntry[]>();
+    for (const v of filtered) {
+      const key = useLocale
+        ? (v.language ?? "Other")
+        : useGender
+          ? cap(v.gender ?? "Other")
+          : useLanguage
+            ? (v.language ?? "Other")
+            : "All";
+      const arr = map.get(key);
+      if (arr) arr.push(v);
+      else map.set(key, [v]);
+    }
+    const entries = [...map.entries()];
+    if (entries.length <= 1) return [] as { key: string; items: VoiceCatalogEntry[] }[];
+    entries.sort((a, b) => {
+      const oa = GROUP_ORDER[a[0]] ?? 999;
+      const ob = GROUP_ORDER[b[0]] ?? 999;
+      return oa === ob ? a[0].localeCompare(b[0]) : oa - ob;
+    });
+    return entries.map(([key, items]) => ({ key, items }));
+  });
+
+  function cap(s: string): string {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+
+  function meta(v: VoiceCatalogEntry): string {
+    // Suppress whichever field is already the group key to avoid the group
+    // header being repeated on every row.
+    const genderPart = !useGender && v.gender ? cap(v.gender) : null;
+    const langPart = !useLanguage && !useLocale && v.language ? v.language : null;
+    return [genderPart, langPart].filter(Boolean).join(" · ");
+  }
+
+  function place() {
+    if (!triggerRef || !panelRef) return;
+    const r = triggerRef.getBoundingClientRect();
+    const panelW = Math.max(r.width, 288);
+    const left = Math.max(8, Math.min(r.left, window.innerWidth - panelW - 8));
+    const ph = panelRef.offsetHeight;
+    const below = r.bottom + 6;
+    const above = r.top - ph - 6;
+    const top = below + ph > window.innerHeight && r.top > ph + 16 ? above : below;
+    panelRef.style.width = `${panelW}px`;
+    panelRef.style.left = `${left}px`;
+    panelRef.style.top = `${Math.max(8, top)}px`;
+  }
+
+  function onDocMouseDown(e: MouseEvent) {
+    const t = e.target as Node | null;
+    if (!t) return;
+    if (triggerRef?.contains(t) || panelRef?.contains(t)) return;
+    open = false;
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Escape") open = false;
+  }
+
+  $effect(() => {
+    if (!open) return;
+    place();
+    searchRef?.focus();
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  });
+
+  function choose(id: string) {
+    onselect(id);
+    open = false;
+    query = "";
+  }
+</script>
+
+<button
+  bind:this={triggerRef}
+  type="button"
+  onclick={() => (open = !open)}
+  class={cn(
+    "border-input bg-background focus-visible:ring-ring inline-flex h-9 w-56 items-center justify-between gap-2 rounded-sm border px-3 text-sm shadow-xs focus-visible:ring-1 focus-visible:outline-none",
+    open && "ring-ring ring-1"
+  )}
+>
+  <span class="truncate text-left">
+    {#if selected}
+      <span>{selected.label}</span>
+    {:else}
+      <span class="text-muted-foreground">Select voice…</span>
+    {/if}
+  </span>
+  <ChevronDown size={14} class="text-muted-foreground shrink-0" />
+</button>
+
+{#if open}
+  <div bind:this={panelRef} use:portal class="fixed z-50" role="listbox">
+    <div
+      class="border-border bg-background text-foreground rounded-md border shadow-lg"
+    >
+      <div class="border-border relative border-b">
+        <Search
+          size={14}
+          class="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2"
+        />
+        <input
+          bind:this={searchRef}
+          bind:value={query}
+          placeholder="Search voices…"
+          class="w-full rounded-t-md py-2 pr-3 pl-8 text-sm outline-none"
+        />
+      </div>
+
+      <div class="max-h-72 overflow-auto py-1">
+        {#if filtered.length === 0}
+          <p class="text-muted-foreground px-3 py-2 text-sm">No voices match “{query}”.</p>
+        {:else if groups.length === 0}
+          {#each filtered as v (v.id)}
+            {@render row(v)}
+          {/each}
+        {:else}
+          {#each groups as g (g.key)}
+            <div
+              class="text-muted-foreground px-3 py-1 text-xs font-semibold tracking-wide uppercase"
+            >
+              {g.key}
+            </div>
+            {#each g.items as v (v.id)}
+              {@render row(v)}
+            {/each}
+          {/each}
+        {/if}
+      </div>
+
+      {#if supportsRefresh}
+        <div class="border-border border-t p-1.5">
+          <button
+            type="button"
+            onclick={() => onrefresh?.()}
+            disabled={loading}
+            class="text-muted-foreground hover:text-foreground inline-flex w-full items-center justify-center gap-1.5 rounded-sm py-1.5 text-xs disabled:opacity-50"
+          >
+            <RefreshCw size={13} class={loading ? "animate-spin" : ""} />
+            {loading ? "Refreshing…" : "Refresh from API"}
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+{#snippet row(v: VoiceCatalogEntry)}
+  <button
+    type="button"
+    onclick={() => choose(v.id)}
+    title={v.description ?? v.label}
+    class={cn(
+      "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm",
+      v.id === value ? "bg-muted" : "hover:bg-muted"
+    )}
+  >
+    <Check size={14} class={cn("shrink-0", v.id === value ? "opacity-100" : "opacity-0")} />
+    <span class="flex-1 truncate">{v.label}</span>
+    {#if meta(v)}
+      <span class="text-muted-foreground shrink-0 text-xs">{meta(v)}</span>
+    {/if}
+  </button>
+{/snippet}

--- a/src/lib/components/layout/app-footer.svelte
+++ b/src/lib/components/layout/app-footer.svelte
@@ -34,7 +34,7 @@
   );
 
   function profileVoiceLabel(profile: VoiceProfile | null): string | null {
-    return profile?.voice_label || profile?.voice || null;
+    return profile?.voice_label ?? null;
   }
 
   async function loadProfileInfo() {

--- a/src/lib/components/play-page.svelte
+++ b/src/lib/components/play-page.svelte
@@ -141,6 +141,7 @@
   };
 
   let config = $state<AppConfig | null>(null);
+  let externalLoad = false;
   let manualText = $state("");
   let lastPlayedContent = $state<string | null>(null);
   let abortRequested = $state(false);
@@ -152,6 +153,7 @@
   } | null>(null);
 
   let unlistenTruncated: (() => void) | null = null;
+  let unlistenConfig: (() => void) | null = null;
 
   // Proxy store state for template readability
   let isPlaying = $derived(playbackStore.isPlaying);
@@ -171,13 +173,15 @@
       const speed = activeProfile?.speed ?? 1.0;
       const pitch = activeProfile?.pitch ?? 1.0;
 
-      console.log("[PlayPage] Config effect triggered - hotkey:", {
-        hotkeyEnabled,
-        hotkeyShortcut
-      });
-
       // Keep playback store in sync so audio plays at correct settings
       playbackStore.syncPlaybackConfig(volume, speed, pitch, activeEffect);
+
+      // ponytail: skip auto-save when config was loaded externally (config-changed event)
+      // to break the reload → save → emit → reload loop
+      if (externalLoad) {
+        externalLoad = false;
+        return;
+      }
 
       const timeout = setTimeout(async () => {
         if (isTauri) {
@@ -192,11 +196,12 @@
     }
   });
 
-  async function loadConfig() {
+  async function loadConfig(external = false) {
     if (!isTauri) {
       config = mockConfig;
       return;
     }
+    if (external) externalLoad = true;
     try {
       config = await invoke<AppConfig>("get_config");
     } catch (e) {
@@ -302,6 +307,14 @@
 
     if (isTauri) {
       try {
+        unlistenConfig = await listen("config-changed", async () => {
+          await loadConfig(true);
+        });
+      } catch {}
+    }
+
+    if (isTauri) {
+      try {
         unlistenTruncated = await listen<{
           original_length: number;
           truncated_length: number;
@@ -320,6 +333,7 @@
 
   onDestroy(() => {
     if (unlistenTruncated) unlistenTruncated();
+    if (unlistenConfig) unlistenConfig();
   });
 </script>
 

--- a/src/lib/components/settings-page.svelte
+++ b/src/lib/components/settings-page.svelte
@@ -12,6 +12,7 @@
   import { Button } from "$lib/components/ui/button/index.js";
   import { Switch } from "$lib/components/ui/switch/index.js";
   import { SettingRow } from "$lib/components/ui/setting-row/index.js";
+  import { Input } from "$lib/components/ui/input/index.js";
   import { Select } from "$lib/components/ui/select/index.js";
   import { invoke } from "$lib/services/tauri";
   import { toast } from "svelte-sonner";
@@ -255,6 +256,23 @@
                       bind:checked={localConfig.trigger.listen_enabled}
                     />
                   </SettingRow>
+                  {#if localConfig.trigger.listen_enabled}
+                    <SettingRow
+                      label={$_("settings.triggers.doubleCopyWindow")}
+                      tooltip={$_("settings.triggers.doubleCopyWindowDescription")}
+                    >
+                      <Input
+                        type="number"
+                        value={String(localConfig.trigger.double_copy_window_ms)}
+                        onchange={(e) => {
+                          const raw = (e.target as HTMLInputElement).value;
+                          localConfig.trigger.double_copy_window_ms =
+                            raw === "" ? 1500 : Math.max(100, Number(raw));
+                        }}
+                        class="w-24"
+                      />
+                    </SettingRow>
+                  {/if}
                   <HotkeySettings bind:localConfig {errors} />
                   {#if localConfig.hud}
                     <SettingRow

--- a/src/lib/composables/use-hud-events.ts
+++ b/src/lib/composables/use-hud-events.ts
@@ -35,6 +35,7 @@ export function useHudEvents() {
       const eventApi = await import("@tauri-apps/api/event");
 
       unlisteners.start = await eventApi.listen<HudStartPayload>("hud:start", (event) => {
+        eventApi.emit("hud:diag:start-received");
         hudStore.handleStart(event.payload);
       });
 
@@ -102,6 +103,10 @@ export function useHudEvents() {
       unlisteners.audioDuration = await eventApi.listen<number>("hud:audio-duration", (event) => {
         hudStore.setAccurateDurationMs(event.payload);
       });
+
+      // Diagnostic: confirm all listeners registered and IPC works
+      await eventApi.emit("hud:diag:listeners-ready");
+      console.log("[HUD] diagnostic listeners-ready event emitted");
     } catch (e) {
       console.error("[HUD] Failed to set up Tauri event listeners:", e);
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -186,6 +186,7 @@ export interface VoiceCatalogEntry {
   label: string;
   language: string | null;
   description: string | null;
+  gender: string | null;
   preview_url: string | null;
 }
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.1.8";
+export const VERSION = "0.1.9";

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -3,25 +3,11 @@
   import HudOverlay from "$lib/components/hud-overlay.svelte";
 
   onMount(() => {
-    console.log("[HUD PAGE] onMount firing");
     // Mark body so the Tailwind base layer skips bg-background for this window
     document.body.setAttribute("data-hud", "");
-
-    // Belt-and-suspenders: force transparent background on html+body
     document.documentElement.style.background = "transparent";
     document.body.style.background = "transparent";
-
-    console.log("[HUD PAGE] data-hud attribute set, background transparent");
   });
-
-  // Catch any errors
-  window.onerror = (msg, _src, line, _col, err) => {
-    console.error("[HUD PAGE] Global error:", msg, "at line", line, err);
-  };
-
-  window.onunhandledrejection = (e) => {
-    console.error("[HUD PAGE] Unhandled rejection:", e.reason);
-  };
 </script>
 
 <svelte:head>

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -2,11 +2,18 @@
   import { onMount } from "svelte";
   import HudOverlay from "$lib/components/hud-overlay.svelte";
 
-  onMount(() => {
+  onMount(async () => {
     // Mark body so the Tailwind base layer skips bg-background for this window
     document.body.setAttribute("data-hud", "");
     document.documentElement.style.background = "transparent";
     document.body.style.background = "transparent";
+
+    // Show the window now that transparent CSS is applied.
+    // We only show once; from here on, HUD is hidden by moving off-screen.
+    if (typeof window !== "undefined" && "__TAURI_INTERNALS__" in window) {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      await getCurrentWindow().show();
+    }
   });
 </script>
 

--- a/src/routes/voices/+page.svelte
+++ b/src/routes/voices/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { Button } from "$lib/components/ui/button/index.js";
-  import { invoke } from "$lib/services/tauri";
+  import { invoke, isTauri } from "$lib/services/tauri";
   import { toast } from "svelte-sonner";
   import { _ } from "svelte-i18n";
   import { showSaveBar, hideSaveBar } from "$lib/stores/save-bar.svelte";
@@ -62,8 +62,22 @@
     return () => hideSaveBar();
   });
 
-  onMount(() => {
-    loadConfig();
+  let unlistenConfig: (() => void) | null = null;
+
+  onMount(async () => {
+    await loadConfig();
+    if (isTauri) {
+      try {
+        const { listen } = await import("@tauri-apps/api/event");
+        unlistenConfig = await listen("config-changed", async () => {
+          await loadConfig();
+        });
+      } catch {}
+    }
+  });
+
+  onDestroy(() => {
+    if (unlistenConfig) unlistenConfig();
   });
 </script>
 


### PR DESCRIPTION
## Summary

Voice picker polish, credential UX improvements, config sync fixes.

### What's in the box

**Credential detection** — New  IPC command checks both  and  without network calls. Profile-manager now uses it to accurately show/hide the "Set up credentials" hint.

**Voice label backfill** — Default profile and config migration now populate  from the voice catalog.  prioritizes the catalog label over the raw voice ID, giving cleaner filenames in history.

**Config-changed listeners** — Play page and Voices page react to the  Tauri event, staying in sync when config changes externally.

**Play-page save loop fix** —  guard prevents the config  from auto-saving when config was loaded via , breaking the infinite reload→save→emit cycle.

**HUD flash fix** — Window starts hidden () and calls  in  after transparent CSS is applied.

**Footer voice label fix** —  instead of  so empty-string labels are preserved.

### Prior changes in this release (already committed)

- Searchable voice picker with live search, gender/locale grouping
- Cartesia voice refresh via API
- `.env` secret loading with per-engine key resolution
- Voice catalog gender field + enriched metadata (OpenAI, Google, Cartesia, Edge, ElevenLabs)
- ElevenLabs static catalog expanded to 21 premade voices