### PR TITLE
feat(ui): refine responsive app experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,142 +1,22 @@
 # AGENTS.md
 
-> For AI coding agents (Hermes-Agent, Pi, OpenCode, KiloCode, Claude Code, Cursor, etc.)
+CopySpeak: A lightwieight and modern AI text-to-speech orchestrator for Windows that reads clipboard text aloud when double-copied. Stack: Svelte 5, Tauri 2.
 
-## Project
+## Rules
 
-CopySpeak - A modern AI text-to-speech orchestrator for Windows that reads clipboard text aloud when double-copied. Stack: Svelte 5, Tauri 2.
+- Fix causes, not symptoms. Report adjacent problems, don't fix them.
+- Never stub, loosen, or comment out check to get green. Broken and loud beats silent and wrong.
+- Unsure or blocked: ask. State assumptions, surface tradeoffs, push back on over-engineering.
 
-## Core Development Rules
+## Workflow
 
-### 1. Think Before Code
-
-- No assume. No hide confusion. Surface tradeoffs.
-- State assumptions. Uncertain → ask.
-- Multiple interpretations → present, no silent pick.
-- Simpler path exist → say so. Push back when warranted.
-- Unclear → stop. Name confusion. Ask.
-
-### 2. Simplicity First
-
-- Min code that solve problem. Nothing speculative.
-- No features beyond ask.
-- No abstractions for single-use code.
-- No "flexibility"/"configurability" not requested.
-- No error handling for impossible cases.
-- 200 lines could be 50 → rewrite.
-- Test: senior eng call this overcomplicated? Yes → simplify.
-
-### 3. Surgical Changes
-
-- Touch only what must. Clean only own mess.
-- No "improve" adjacent code/comments/format.
-- No refactor things not broken.
-- Match existing style even if disagree.
-- Unrelated dead code → mention, no delete.
-- Own changes orphan imports/vars → remove.
-- Pre-existing dead code → leave unless asked.
-- Test: every changed line trace to user request.
-
-### 4. Goal-Driven Execution
-
-- Define success. Loop until verified.
-- "Add validation" → write failing tests, make pass.
-- "Fix bug" → write reproducing test, make pass.
-- "Refactor X" → tests pass before and after.
-- Multi-step → state plan: [step] → verify: [check].
-
-### 5. Testing / Committing
-
-DO NOT run checks. ALWAYS ASK USER for explicit confirmation before running any verification, linting, type-check, or build commands.
-
-DO NOT commit changes without explicit user confirmation. Before ending a task, ask whether to run checks and commit. If the user confirms committing, generate a suitable Conventional Commits message that summarizes the diff concisely.
-
-- `bun format` - prettier format.
-- `bun check` - types + svelte-check.
-- `bun build` - production build.
-
-Use running Tauri dev server.
-
-## Efficiency
-
-- Read before write. Each file once.
-- Edit over rewrite. No write-delete-rewrite cycles.
-- Test once, fix, verify once.
-- Budget: 50 tool calls.
-- Stuck → ask. No dead ends.
-- No sycophantic openers/fluff.
-- Never guess paths.
-
-## Code Style
-
-### Naming Conventions
-
-- Files (kebab-case) & Svelte components (kebab-case.svelte)
-- Variables/functions (camelCase) & Types/interfaces (PascalCase)
-- Constants (UPPER_SNAKE_CASE) & Rust modules (snake_case)
-
-### Svelte Rules
-
-- Use `$state`, `$derived`, `$props`, `$effect` (not `$:`)
-- Use `onclick` NOT `on:click`
-- Call derived signals in templates: `doubled()` not `doubled`
-- Import from `$app/state` not `$app/stores`
-
-### TypeScript Rules
-
-- Strict mode enabled
-- No unused variables
-- Explicit return types for public functions
-- Prefer `interface` over `type` for object shapes
-- Use `satisfies` instead of type assertions
-- Never use `!` non-null assertion
-
-## Git Workflow
-
-- **NEVER commit directly to `main`** - all changes via PRs
-- **Always create a new branch** before starting any new feature, fix, refactor, or version work. Never work on an existing branch that isn't yours.
-- Work on feature branches: `feature/`, `fix/`, `refactor/`, `docs/`
-- Use versioned dev branches for releases: `develop/0.1.0`, `develop/0.2.0`, etc.
-- Open PRs targeting `main` (or `develop/*` for larger efforts)
-- **Bump version when finishing a task**: after completing work and before opening a PR, run `bun run bump` (patch), `bun run bump:minor`, or `bun run bump:major` to bump all version files (package.json, Cargo.toml, tauri.conf.json, version.ts, README.md). Choose the bump type based on the scope of changes. Commit the version bump as part of the PR.
-
-## Best Practices
-
-- Follow existing code patterns
-- Keep responses concise (1-3 sentences)
-- Comments explain "why" not "what"
-- Update CHANGELOG.md for notable changes (features, fixes, breaking changes). Follow [Keep a Changelog](https://keepachangelog.com/) sections: Added, Changed, Deprecated, Removed, Fixed, Security
-
-## Reasoning Discipline
-
-- Prefer sharp model over pretty one.
-- If uncertain, say what known/inferred/open.
-
-## Changelog Maintenance
-
-**For all PRs and commits affecting functionality:**
-
-- Update `CHANGELOG.md` under `[Unreleased]`
-- Use categories: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`, `Breaking Changes`
-- List specific changes with implementation details (functions, structs, features added)
-- Include `BREAKING CHANGE:` prefix for incompatible API changes
-
-Example:
-
-```markdown
-### Added
-
-- Feature description with implementation details
-  - Specific component/function details
-
-### Changed
-
-- Modified existing functionality description
-
-### Breaking Changes
-
-- `OldClass::method()` now requires `newParam` parameter
-```
+- Use `i-have-adhd` skill: next action first, numbered steps, no preamble.
+- Never run `bun run tauri dev` to verify change; already running. Use `bun run check && bun run test`.
+- Never run checks or commit without explicit confirmation. Ask before concluding task.
+- End with one concrete next step; user approves. Use shape: `If you want, I can do X next. React with ✅ to run it.` Several viable: list up to 3, one line each, best first.
+- Hand-off prompts only include what next session can't access: decisions made, dead ends, ongoing states, next steps. Don't repeat AGENTS.md.
+- Avoid image-previewing. Only user verifies/approves visually.
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/).
 
 ## Documentation
 
@@ -144,20 +24,25 @@ Example:
 
 - **docs_internal/ (Internal Docs)**: **project-overview.md** (project context and key decisions), **requirements.md** (feature requirements and traceability), **architecture.md** (system architecture and design), **development_guide.md** (setup and development workflow), **tts_backends.md** (TTS engine integration guide), **brutalist_design.md** (UI design system and aesthetics), **roadmap.md** (development roadmap and phases), **code-patterns-reference.md** (Svelte 5, Rust, and Tauri IPC code examples).
 
-## Final Reply Tails
+## Keeping this file current
 
-When answer suggests next step, end with compact executable tail, not vague fluff.
+File logs failures, not wishlist. Every line below exists because it went wrong at least once. On mistake, correction, or undocumented discovery about codebase:
 
-Use shape: `If you want, I can do X next. React with ✅ to run it.`
+1. Add one line to active failure log below, imperative, describing correct behaviour.
+2. Keep specific to this repo. General advice belongs nowhere.
+3. Fix is workflow not rule: put in `.agents/skills/` and link from here.
+4. Include change in same commit, mention in summary.
 
-Rules: Offer ✅ hook only if next step wired to real action. One suggested next step. Don't use tail for pure facts, refusals, one-off answers with no real follow-up.
+Keep active failure log short: entries for work not in `## Active work` move to [`.agents/failure-log.md`](.agents/failure-log.md). Loaded every session; long context makes you less reliable, not more. Architecture detail outgrows usefulness: move to `.agents/architecture.md` or a skill.
 
-## Final Rule
+## Active failure log
 
-Be assistant you'd want to talk to at 2AM. Not corporate drone. Not sycophant. Just useful.
+- Present history batches as one reading in `recent-history.svelte`; preserve fragment order for full text, playback, and whole-reading deletion.
+- Show pagination as a part count on history rows; keep Play/Stop/Replay on the reading's button instead of adding a lower playback bar.
+- Resolve history voice labels by both engine and voice ID using profiles/catalog; retain raw IDs for playback and tooltips.
+- Hide the playback button's decorative spinner from accessibility naming so synthesis keeps the action named “Stop”.
 
 <!-- rtk-instructions v2 -->
-
 ## RTK (Rust Token Killer) - Token-Optimized Commands
 
 ## Golden Rule
@@ -173,6 +58,5 @@ git add . && git commit -m "msg" && git push
 # ✅ Correct
 rtk git add . && rtk git commit -m "msg" && rtk git push
 ```
-
 Full command reference (which tools have dedicated filters, and their savings): the `rtk-commands` skill in `.agents/skills/rtk-commands/`.
 <!-- /rtk-instructions -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14] - 2026-09-06
+
 ### Added
 
 - **Uninstall for every local TTS engine** — new `scripts/uninstall-engine.ps1 -Engine <kitten|piper|kokoro|pocket|edge>` removes the uv-managed engine directory and/or runs `uv tool uninstall`, streaming the same `[STEP]/[DONE]/[ERROR]` markers as the installers. Exposed as the `uninstall_engine` Tauri command and an Uninstall button (with confirmation) in the install dialog.
@@ -21,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Responsive desktop UI** — the main window now starts at 775×580, resizes down to 360×400, and keeps navigation, content, controls, and settings usable at narrow widths.
+- **Flatter app layout** — Play, History, Voices, Engines, Settings, and Onboarding now share the same divider-led visual language without nested cards. The Play page uses a larger labeled editor and responsive quick settings.
+- **Reading-level history** — paginated fragments now render as one reading with ordered full text, one playback/delete row, resolved engine and voice labels, duration, and a compact part count.
+- **Cartesia is the fresh-install default** — new configs select the bundled Cartesia profile, and onboarding accepts and validates a Cartesia API key without spending synthesis credits.
 - **ElevenLabs streaming pins `pcm_24000` instead of `pcm_44100`** — ElevenLabs gates `pcm_44100` output behind its Pro tier, so every streamed fragment failed at `phase=headers` with 403 `output_format_not_allowed` on non-Pro accounts. `STREAM_OUTPUT_FORMAT` and the `ChunkStream` meta now use 24 kHz / mono / 16-bit; the end-of-stream WAV wrap inherits the rate from the stream meta (no hardcoded rate), and the wiremock request-shape test asserts the new pin.
 - **`edge` no longer has an installer** — `scripts/install-edge-tts.ps1` is gone and the Engines page no longer offers an Install dialog for it (no `installerId`). `engine_status` still probes `edge-tts` on PATH, and a missing binary surfaces `uv tool install edge-tts` in the synthesis error instead of a `pip install` hint.
 - **Install dialog is driven by engine metadata** — the hard-coded `SHARED`/`ENGINE_SIZE` maps moved into `engine-meta.ts` as `voiceMode` (`per-voice` | `shared` | `none`) and `downloadSize`. `none` engines (uv, pocket) no longer render a meaningless voice checklist.
@@ -32,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **History playback controls** — each reading now uses one Play/Stop button, retains Play for replay, starts replay from the beginning, and lets another history row take over active playback. Loading decoration no longer changes the accessible action name.
+- **History voice names** — saved readings resolve labels by engine and voice ID through profiles and the engine catalog; unknown IDs show “Saved voice” while preserving the raw ID in the tooltip.
 - **ElevenLabs live PCM playback corrupted samples at network chunk boundaries** — `PcmStreamScheduler` now carries incomplete 16-bit interleaved frames into the next chunk instead of dropping their bytes before `pcm16LeToFloat32Channels`. Carry state is cleared at fragment end and stop; empty terminal events remain control-only. Development-only chunk size, arrival-gap, buffered-duration, and underrun diagnostics distinguish byte-alignment corruption from network starvation without increasing the 250 ms prebuffer.
 - **Engine installers failed when launched from the app** — tauri's `resource_dir()` is built from a canonicalized exe path; on Windows `std::fs::canonicalize` returns `\\?\` verbatim paths, which leaked into `powershell -File` and `$PSScriptRoot`, breaking the `lib/copyspeak-engine-install.ps1` dot-source in every installer. `resolve_script` now strips the prefix once at the source, so installers work in dev and packaged builds; the per-script `$PSScriptRoot -replace` workarounds were removed.
 - **`install-kokoro.ps1` did not parse under Windows PowerShell 5.1** — the file is BOM-less UTF-8, which 5.1 reads as ANSI, so an em dash inside a `Write-Host` string decoded to bytes containing a `"` and terminated the literal early. The script failed before running a single line on any machine without `pwsh`. All installer scripts are now ASCII-only, and the new self-check enforces it.
@@ -564,7 +572,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SSML support removed** — SSML markup passthrough feature removed
 - **Streaming TTS mode removed** — Simplified to paginated synthesis only
 
-[Unreleased]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.13...HEAD
+[Unreleased]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/ilyaizen/CopySpeak/compare/v0.1.10...v0.1.11

--- a/docs_internal/architecture.md
+++ b/docs_internal/architecture.md
@@ -343,7 +343,7 @@ GET /health ─► liveness probe
 ```json
 {
   "trigger":     { "listen_enabled": true, "double_copy_window_ms": 1500, "max_text_length": 100000 },
-  "tts":         { "active_backend": "edge", "...per-engine blocks": "api_key, voice, model" },
+  "tts":         { "active_backend": "cartesia", "...per-engine blocks": "api_key, voice, model" },
   "playback":    { "on_retrigger": "queue", "volume": 100, "playback_speed": 1.35, "pitch": 1.15 },
   "hud":         { "enabled": true, "position": "bottom-center", "width": 300, "height": 140, "opacity": 0.85 },
   "hotkey":      { "enabled": false, "shortcut": "Super+Shift+A" },

--- a/docs_internal/brutalist_design.md
+++ b/docs_internal/brutalist_design.md
@@ -1,5 +1,34 @@
 # Brutalist Redesign Spec
 
+## Current implementation — 0.1.14
+
+The historical specification below is not an exact description of today's UI.
+Use `src/routes/+layout.css` as the source of truth for the existing Lato typography,
+teal-gray semantic colors, light/dark themes, and small corner radii.
+
+- The main window is resizable from 360 × 400, initially 775 × 580. The HUD remains fixed-size.
+- Play uses a labeled text editor and flat quick-control rows. At widths below 768px,
+  controls follow the editor; wider windows place them alongside it. The content area scrolls
+  when the window is short, with navigation and footer outside that scroll area.
+- History presents each reading as one row, joining audio fragments in playback order.
+  Rows share a two-line preview, timestamp, engine/voice, duration, playback and Delete.
+  Paginated readings carry a small part count, including the expected total when recorded.
+  Voice names come from a matching profile or the engine catalog; unknown voices show
+  “Saved voice”, with the original identifier available in the metadata tooltip.
+  Full text opens in a dialog. There are no fragment accordions or resynthesis controls.
+- Playback requires saved audio for every recorded part. A single button offers Play,
+  Stop while playing, and Replay afterward, both on the front page and on the owning
+  history row. There is no lower playback bar. Replay starts the reading from the beginning.
+  Deleting a reading removes all its recorded parts.
+- Navigation and settings rows wrap at narrow widths; long text must not force wider content.
+
+Validation (2026-09-06): `bun run check` passed with 0 errors and 0 warnings;
+`bun run test` passed all 32 tests. Visual review in the running app remains pending.
+The separate Svelte analyzer reports existing route-resolution and unkeyed-loop
+issues in the surrounding shell/settings code; these are outside this UI change.
+
+## Historical specification
+
 > **Date:** 2026-03-25
 > **Version:** v0.2.2
 > **Reference:** shadcn-svelte Dark Mode Documentation

--- a/docs_internal/project-overview.md
+++ b/docs_internal/project-overview.md
@@ -1,6 +1,6 @@
 # CopySpeak Project Overview
 
-**Last Updated:** 2026-03-25
+**Last Updated:** 2026-09-05
 
 ## What This Is
 
@@ -12,9 +12,9 @@ CopySpeak is a lightweight Windows desktop application that wraps AI Text-to-Spe
 
 ## Stack
 
-- **Frontend**: Svelte 5 + SvelteKit + Tailwind CSS v4.2 + shadcn-svelte
+- **Frontend**: Svelte 5 + SvelteKit + Tailwind CSS v4 + shadcn-svelte
 - **Backend**: Rust (Tauri v2)
-- **IPC**: `commands.rs` → `main.rs` → frontend via `@tauri-apps/api`
+- **IPC**: `src-tauri/src/commands/` modules registered in `main.rs`; frontend calls via `@tauri-apps/api`
 - **State**: `Mutex<T>` via Tauri's `app.manage()`
 
 ## Constraints
@@ -25,7 +25,15 @@ CopySpeak is a lightweight Windows desktop application that wraps AI Text-to-Spe
 
 ## Current State
 
-The app is at a pre-production v0.0.x state — core clipboard-to-speech flow is complete and working. Phase 9 (TTS Engine Overhaul) was recently completed, consolidating engines and removing HTTP backend.
+The working version is **0.1.14**, as recorded in `package.json`, `src-tauri/Cargo.toml`,
+and `src-tauri/tauri.conf.json`. The main routes are Play, History, Voices, Engines,
+and Settings, with separate onboarding and HUD routes. Voice profiles supply speed,
+pitch, and effects; volume is global. Shared Svelte stores own playback, listening,
+and history state. Saved batches replay through the existing fragment queue.
+
+The current UI work adds window resizing, responsive controls, and a unified history
+reading layout. See [Current design implementation](brutalist_design.md#current-implementation--0114).
+Older decisions and deferred-feature lists below are historical and need a separate audit.
 
 ## Key Decisions
 

--- a/src-tauri/src/config/tests.rs
+++ b/src-tauri/src/config/tests.rs
@@ -255,13 +255,21 @@ mod tests {
     // ========== TTS Profile / Migration Tests ==========
 
     #[test]
-    fn test_default_tts_config_has_one_default_profile() {
+    fn test_default_tts_config_uses_cartesia_profile() {
         let tts = TtsConfig::default();
+        assert_eq!(TtsEngine::default(), TtsEngine::Cartesia);
         assert_eq!(tts.schema_version, 4);
-        assert_eq!(tts.active_profile_id, "default");
+        assert_eq!(tts.active_backend, TtsEngine::Cartesia);
         assert_eq!(tts.profiles.len(), 5);
         assert_eq!(tts.profiles[0].id, "default");
         assert_eq!(tts.profiles[0].engine, TtsEngine::Edge);
+        assert_eq!(
+            tts.profiles
+                .iter()
+                .find(|profile| profile.id == tts.active_profile_id)
+                .map(|profile| &profile.engine),
+            Some(&TtsEngine::Cartesia)
+        );
     }
 
     #[test]

--- a/src-tauri/src/config/tts.rs
+++ b/src-tauri/src/config/tts.rs
@@ -25,7 +25,7 @@ pub enum TtsEngine {
 
 impl Default for TtsEngine {
     fn default() -> Self {
-        TtsEngine::Edge
+        TtsEngine::Cartesia
     }
 }
 
@@ -940,15 +940,16 @@ pub(crate) fn migrate_add_kitten_profile_v4(tts: &mut TtsConfig) {
 
 impl Default for TtsConfig {
     fn default() -> Self {
+        let cartesia_profile = default_cartesia_profile();
         Self {
             schema_version: 4,
-            active_backend: TtsEngine::Edge,
-            active_profile_id: "default".into(),
+            active_backend: TtsEngine::Cartesia,
+            active_profile_id: cartesia_profile.id.clone(),
             profiles: vec![
                 VoiceProfile::default(),
                 default_kitten_profile(),
                 default_elevenlabs_profile(),
-                default_cartesia_profile(),
+                cartesia_profile,
                 default_google_profile(),
             ],
             preset: "kitten-tts".into(),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,9 @@
         "title": "CopySpeak",
         "width": 775,
         "height": 580,
-        "resizable": false,
+        "resizable": true,
+        "minWidth": 360,
+        "minHeight": 400,
         "center": true,
         "visible": true,
         "devtools": true

--- a/src/lib/components/engine/engine-panel.svelte
+++ b/src/lib/components/engine/engine-panel.svelte
@@ -54,8 +54,8 @@
   }
 </script>
 
-<section class="border-border overflow-hidden rounded-lg border">
-  <header class="bg-muted/50 border-border flex items-start justify-between gap-3 border-b p-4">
+<section>
+  <header class="border-border flex items-start justify-between gap-3 border-b pb-4">
     <div class="min-w-0">
       <h2 class="text-lg font-semibold">{$_(`engine.${entry.id}.title`)}</h2>
       <p class="text-muted-foreground mt-1 text-sm">{$_(`engine.${entry.id}.description`)}</p>
@@ -69,7 +69,7 @@
     </button>
   </header>
 
-  <div class="space-y-4 p-4">
+  <div class="space-y-4 py-4">
     {#if entry.credential === "api_key" || entry.credential === "api_key_endpoint"}
       {#if entry.credentialTarget}
         <div class="space-y-2">

--- a/src/lib/components/engine/engine-setup.svelte
+++ b/src/lib/components/engine/engine-setup.svelte
@@ -125,11 +125,11 @@
   });
 </script>
 
-<div class="flex flex-row items-start gap-2">
-  <aside class="w-36 shrink-0 self-stretch">
-    <nav class="space-y-0.5">
+<div class="flex min-w-0 flex-col items-stretch gap-4 sm:flex-row sm:items-start sm:gap-5">
+  <aside class="min-w-0 shrink-0 self-stretch sm:w-36">
+    <nav class="grid grid-cols-2 gap-0.5 sm:block sm:space-y-0.5">
       <p
-        class="text-muted-foreground px-2 pt-1 pb-1 text-[11px] font-semibold tracking-wide uppercase"
+        class="text-muted-foreground col-span-2 px-2 pt-1 pb-1 text-[11px] font-semibold tracking-wide uppercase sm:block"
       >
         {$_("engines.cloud")}
       </p>
@@ -145,7 +145,7 @@
         </button>
       {/each}
       <p
-        class="text-muted-foreground px-2 pt-3 pb-1 text-[11px] font-semibold tracking-wide uppercase"
+        class="text-muted-foreground col-span-2 px-2 pt-3 pb-1 text-[11px] font-semibold tracking-wide uppercase sm:block"
       >
         {$_("engines.local")}
       </p>

--- a/src/lib/components/engine/profile-manager.svelte
+++ b/src/lib/components/engine/profile-manager.svelte
@@ -508,9 +508,11 @@
   }
 </script>
 
-<div class="border-border overflow-hidden rounded-lg border">
+<div>
   <!-- Header: title + actions -->
-  <div class="bg-muted/50 border-border flex items-center justify-between border-b p-4">
+  <div
+    class="border-border flex flex-wrap items-center justify-between gap-3 border-b pb-4"
+  >
     <div>
       <h2 class="text-lg font-semibold">Voice Profiles</h2>
       <p class="text-muted-foreground mt-1 text-sm">
@@ -555,7 +557,7 @@
     </div>
   </div>
 
-  <div class="space-y-1 p-4">
+  <div class="space-y-1 border-b py-4">
     <SettingRow label="Active Profile">
       <Select
         options={profileOptions}
@@ -567,9 +569,9 @@
   </div>
 
   {#if active}
-    <div class="border-border space-y-4 border-t p-4">
+    <div class="space-y-5 py-5">
       <!-- Identity -->
-      <section class="border-border bg-muted/30 rounded-lg border p-3">
+      <section class="border-border border-b pb-5">
         <p class="text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase">
           Identity
         </p>
@@ -579,7 +581,7 @@
       </section>
 
       <!-- Engine & Voice -->
-      <section class="border-border bg-muted/30 space-y-3 rounded-lg border p-3">
+      <section class="border-border space-y-3 border-b pb-5">
         <p class="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
           Engine & Voice
         </p>
@@ -655,7 +657,7 @@
       </section>
 
       <!-- Sound -->
-      <section class="border-border bg-muted/30 space-y-3 rounded-lg border p-3">
+      <section class="border-border space-y-3 border-b pb-5">
         <p class="text-muted-foreground text-xs font-semibold tracking-wide uppercase">Sound</p>
         <SettingRow label="Speed">
           <div class="flex w-56 items-center gap-2">
@@ -701,7 +703,7 @@
 
       <!-- Advanced: engine-specific options + docs -->
       {#if activeCatalogEntry}
-        <section class="border-border bg-muted/30 space-y-3 rounded-lg border p-3">
+        <section class="border-border space-y-3 border-b pb-5">
           <div class="flex items-center justify-between gap-2">
             <p class="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
               {activeCatalogEntry.label}

--- a/src/lib/components/global-player.svelte
+++ b/src/lib/components/global-player.svelte
@@ -1,77 +1,19 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { cn } from "$lib/utils.js";
   import { playbackStore } from "$lib/stores/playback-store.svelte";
-  import { isTauri } from "$lib/services/tauri.js";
 
   let audioEl = $state<HTMLAudioElement | null>(null);
-  let clipboardCopied = $state(false);
-  let clipboardTimer: ReturnType<typeof setTimeout> | null = null;
-
-  let isPlaying = $derived(playbackStore.isPlaying);
-  let isPaused = $derived(playbackStore.isPaused);
-  let isSynthesizing = $derived(playbackStore.isSynthesizing);
-
-  let infoBubble = $derived(isPlaying || isSynthesizing || clipboardCopied);
-
-  let unlistenClipboard: (() => void) | null = null;
 
   onMount(async () => {
     playbackStore.setAudioElement(audioEl);
     await playbackStore.setupListeners();
-
-    if (isTauri) {
-      try {
-        const { listen } = await import("@tauri-apps/api/event");
-        unlistenClipboard = await listen("clipboard-change", () => {
-          clipboardCopied = true;
-          if (clipboardTimer) clearTimeout(clipboardTimer);
-          clipboardTimer = setTimeout(() => {
-            clipboardCopied = false;
-          }, 2000);
-        });
-      } catch {
-        // Ignore
-      }
-    }
   });
 
   onDestroy(() => {
     playbackStore.teardownListeners();
     playbackStore.setAudioElement(null);
-    if (unlistenClipboard) unlistenClipboard();
-    if (clipboardTimer) clearTimeout(clipboardTimer);
   });
 </script>
 
 <!-- svelte-ignore a11y_media_has_caption -->
 <audio bind:this={audioEl} style="display:none"></audio>
-
-{#if infoBubble}
-  <div
-    class={cn(
-      "fixed right-4 bottom-14 z-50 flex items-center gap-2 rounded-full px-4 py-2 shadow-lg transition-colors",
-      isPlaying || isSynthesizing
-        ? "bg-primary text-primary-foreground"
-        : "bg-secondary text-secondary-foreground"
-    )}
-  >
-    <div
-      class={cn(
-        "h-2 w-2 rounded-full",
-        isPlaying || isSynthesizing
-          ? cn("bg-primary-foreground", (isSynthesizing || !isPaused) && "animate-pulse")
-          : "bg-muted-foreground"
-      )}
-    ></div>
-    <span class="text-sm font-medium">
-      {#if isSynthesizing && !isPlaying}
-        Processing...
-      {:else if isPlaying}
-        {isPaused ? "Paused" : "Playing"}
-      {:else}
-        Copied to Clipboard
-      {/if}
-    </span>
-  </div>
-{/if}

--- a/src/lib/components/history-page.svelte
+++ b/src/lib/components/history-page.svelte
@@ -12,6 +12,6 @@
   });
 </script>
 
-<div class="mx-auto w-full max-w-4xl space-y-4">
+<div class="mx-auto w-full min-w-0 max-w-4xl">
   <RecentHistory limit={Infinity} />
 </div>

--- a/src/lib/components/layout/app-footer.svelte
+++ b/src/lib/components/layout/app-footer.svelte
@@ -125,7 +125,7 @@
 
           <DropdownMenu bind:open={dropdownOpen}>
             <DropdownMenuTrigger
-              class="hover:bg-muted/50 focus:ring-ring cursor-pointer rounded px-1 py-0.5 text-xs transition-colors focus:ring-2 focus:ring-offset-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              class="hover:bg-muted/50 focus:ring-ring min-w-0 cursor-pointer truncate rounded px-1 py-0.5 text-xs transition-colors focus:ring-2 focus:ring-offset-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
               aria-label={`Switch profile: ${activeProfile.name}`}
             >
               <span class="text-card-foreground truncate">{activeProfile.name}</span>
@@ -177,7 +177,7 @@
         {/if}
       </div>
 
-      <div class="flex items-center gap-2">
+      <div class="flex shrink-0 items-center gap-2">
         <UpdateChecker />
         <span class="bg-border mx-2 h-3 w-px"></span>
         <span class="text-muted-foreground shrink-0 text-xs">v{VERSION}</span>

--- a/src/lib/components/layout/app-header.svelte
+++ b/src/lib/components/layout/app-header.svelte
@@ -73,7 +73,7 @@
 </script>
 
 <header class="border-border bg-background z-50 border-b" data-testid="app-header">
-  <div class="flex items-center justify-between px-6 py-3">
+  <div class="flex min-w-0 flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6">
     <div class="flex items-center gap-3">
       <a href="/" class="flex items-center gap-3">
         <img src="/app-logo.png" alt="CopySpeak Logo" class="h-10 w-10" />
@@ -83,8 +83,8 @@
         </div>
       </a>
     </div>
-    <div class="flex items-center gap-4">
-      <nav class="flex items-center gap-1">
+    <div class="min-w-0 max-w-full">
+      <nav aria-label="Main navigation" class="flex flex-wrap items-center gap-1">
         {#each navItems as item}
           {@const isActive =
             item.href === "/" ? page.url.pathname === "/" : page.url.pathname.startsWith(item.href)}
@@ -92,7 +92,7 @@
           <a
             href={item.href}
             data-testid="nav-{item.id}"
-            class="focus-visible:ring-ring inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 {isActive
+            class="focus-visible:ring-ring inline-flex items-center justify-center rounded-md px-2 py-2 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 {isActive
               ? 'bg-muted text-foreground'
               : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'}"
             aria-current={isActive ? "page" : undefined}

--- a/src/lib/components/play-page.svelte
+++ b/src/lib/components/play-page.svelte
@@ -157,7 +157,6 @@
 
   // Proxy store state for template readability
   let isPlaying = $derived(playbackStore.isPlaying);
-  let isPaused = $derived(playbackStore.isPaused);
 
   // Sync playback config to store and auto-save (debounced)
   $effect(() => {
@@ -215,7 +214,9 @@
   type PlayMode = "play" | "replay" | "disabled";
   let playMode: PlayMode = $derived(
     currentContent
-      ? playbackStore.hasCachedAudio && currentContent === lastPlayedContent
+      ? playbackStore.hasCachedAudio &&
+        !playbackStore.historyReadingId &&
+        currentContent === lastPlayedContent
         ? "replay"
         : "play"
       : "disabled"
@@ -246,20 +247,6 @@
         await invoke("stop_speaking");
       } catch (error) {
         console.error("Failed to stop speaking:", error);
-      }
-    }
-  }
-
-  async function handleTogglePause() {
-    // Toggle pause in frontend
-    playbackStore.handleTogglePause();
-
-    // Also notify backend for consistency
-    if (isTauri) {
-      try {
-        await invoke("toggle_pause");
-      } catch (error) {
-        console.error("Failed to toggle pause:", error);
       }
     }
   }
@@ -335,30 +322,30 @@
   });
 </script>
 
-<div class="flex min-h-0 flex-1 flex-col gap-4">
-  <div class="grid min-h-0 flex-1 grid-cols-3 gap-4">
-    {#if config}
-      <div class="min-h-0">
-        <QuickSettings bind:config />
+<div class="flex min-w-0 flex-1 flex-col gap-4">
+  <div class="grid min-w-0 flex-1 grid-cols-1 gap-6 md:grid-cols-[minmax(0,1fr)_13rem]">
+    <section aria-labelledby="reader-heading" class="flex min-w-0 flex-col gap-3">
+      <div>
+        <h2 id="reader-heading" class="text-lg font-bold tracking-tight">Read aloud</h2>
+        <p id="reader-hint" class="text-muted-foreground text-sm">
+          Paste text here, or copy it twice anywhere.
+        </p>
       </div>
-    {/if}
-    <div
-      class="border-border bg-card col-span-2 flex min-h-0 flex-1 flex-col rounded-lg border p-3 shadow-sm"
-    >
+      <label for="reading-text" class="sr-only">Text to read aloud</label>
       <Textarea
-        class="min-h-0 flex-1 resize-none"
+        id="reading-text"
+        aria-describedby="reader-hint"
+        class="min-h-48 flex-1 resize-none field-sizing-fixed p-4 text-base leading-relaxed"
         placeholder={$_("play.placeholder")}
         bind:value={manualText}
       />
-      <div class="mt-2 flex items-center gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <PlaybackControls
           {isPlaying}
-          {isPaused}
           isSynthesizing={playbackStore.isSynthesizing}
           {playMode}
           onPlay={handlePlay}
           onStop={handleStop}
-          onTogglePause={handleTogglePause}
           onAbort={handleAbort}
         />
         {#if manualText}
@@ -366,11 +353,19 @@
             >{$_("play.clear")}</Button
           >
         {/if}
-        <span class="text-muted-foreground ml-auto text-xs">
+        <span class="text-muted-foreground ml-auto text-xs whitespace-nowrap tabular-nums">
           {$_("play.characters", { values: { count: manualText.length.toLocaleString() } })}
         </span>
       </div>
-    </div>
+    </section>
+    {#if config}
+      <aside
+        aria-label="Reading controls"
+        class="border-border min-w-0 border-t pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-5"
+      >
+        <QuickSettings bind:config />
+      </aside>
+    {/if}
   </div>
 
   {#if error}

--- a/src/lib/components/playback-controls.svelte
+++ b/src/lib/components/playback-controls.svelte
@@ -1,71 +1,34 @@
 <script lang="ts">
   import { Button } from "$lib/components/ui/button/index.js";
   import { Spinner } from "$lib/components/ui/spinner/index.js";
+  import { Play, Square, RotateCcw } from "@lucide/svelte";
   import { _ } from "svelte-i18n";
 
   type PlayMode = "play" | "replay" | "history" | "disabled";
 
-  let { isPlaying, isPaused, isSynthesizing, playMode, onPlay, onStop, onTogglePause, onAbort } =
-    $props<{
-      isPlaying: boolean;
-      isPaused: boolean;
-      isSynthesizing: boolean;
-      playMode: PlayMode;
-      onPlay: () => void;
-      onStop: () => void;
-      onTogglePause: () => void;
-      onAbort: () => void;
-    }>();
+  let { isPlaying, isSynthesizing, playMode, onPlay, onStop, onAbort } = $props<{
+    isPlaying: boolean;
+    isSynthesizing: boolean;
+    playMode: PlayMode;
+    onPlay: () => void;
+    onStop: () => void;
+    onAbort: () => void;
+  }>();
 
-  // Determine button states
-  const canPlay = $derived(!isSynthesizing && !isPlaying && playMode !== "disabled");
+  const canStop = $derived(isPlaying || isSynthesizing);
 </script>
 
-<div class="flex flex-wrap items-center gap-2">
-  <!-- Status indicator when synthesizing -->
-  {#if isSynthesizing}
-    <div class="bg-muted text-muted-foreground flex items-center gap-2 rounded-md px-3 py-2">
-      <Spinner class="h-4 w-4" />
-      <span class="text-sm">{$_("play.processing")}</span>
-    </div>
-  {/if}
-
-  <!-- Play/Replay button — always visible -->
-  <Button
-    variant="default"
-    onclick={onPlay}
-    disabled={!canPlay}
-    title={playMode === "replay"
+<Button
+  variant={canStop ? "secondary" : "default"}
+  onclick={isSynthesizing ? onAbort : isPlaying ? onStop : onPlay}
+  disabled={!canStop && playMode === "disabled"}
+  title={canStop
+    ? $_("play.stopTooltip")
+    : playMode === "replay"
       ? $_("play.replayTooltip")
-      : playMode === "history"
-        ? $_("play.playLatestTooltip")
-        : $_("play.playTooltip")}
-  >
-    {playMode === "replay" ? $_("play.replay") : $_("play.play")}
-  </Button>
-
-  <!-- Pause/Resume button — only when playing -->
-  {#if isPlaying}
-    <Button
-      variant="default"
-      onclick={onTogglePause}
-      title={isPaused ? $_("play.resumeTooltip") : $_("play.pauseTooltip")}
-    >
-      {isPaused ? $_("play.resume") : $_("play.pause")}
-    </Button>
-  {/if}
-
-  <!-- Stop button — only when playing -->
-  {#if isPlaying}
-    <Button variant="destructive" onclick={onStop} title={$_("play.stopTooltip")}
-      >{$_("play.stop")}</Button
-    >
-  {/if}
-
-  <!-- Abort button — only when synthesizing or playing -->
-  {#if isSynthesizing || isPlaying}
-    <Button variant="destructive" onclick={onAbort} title={$_("play.abortTooltip")}>
-      {$_("play.abort")}
-    </Button>
-  {/if}
-</div>
+      : $_("play.playTooltip")}
+>
+  {#if isSynthesizing}<Spinner aria-hidden="true" />{:else if isPlaying}<Square
+    />{:else if playMode === "replay"}<RotateCcw />{:else}<Play />{/if}
+  {canStop ? $_("play.stop") : playMode === "replay" ? $_("play.replay") : $_("play.play")}
+</Button>

--- a/src/lib/components/playback-controls.test.ts
+++ b/src/lib/components/playback-controls.test.ts
@@ -1,0 +1,31 @@
+import { expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { waitForI18nReady } from "$lib/i18n";
+import PlaybackControls from "./playback-controls.svelte";
+
+it("uses one button for play, stop, replay, and cancelling synthesis", async () => {
+  await waitForI18nReady();
+  const onPlay = vi.fn();
+  const onStop = vi.fn();
+  const onAbort = vi.fn();
+  const view = render(PlaybackControls, {
+    isPlaying: false,
+    isSynthesizing: false,
+    playMode: "play",
+    onPlay,
+    onStop,
+    onAbort
+  });
+  await fireEvent.click(view.getByRole("button", { name: "Play" }));
+  expect(onPlay).toHaveBeenCalledTimes(1);
+  await view.rerender({ isPlaying: true });
+  expect(view.getAllByRole("button")).toHaveLength(1);
+  await fireEvent.click(view.getByRole("button", { name: "Stop" }));
+  expect(onStop).toHaveBeenCalledTimes(1);
+  await view.rerender({ isPlaying: false, playMode: "replay" });
+  await fireEvent.click(view.getByRole("button", { name: "Replay" }));
+  expect(onPlay).toHaveBeenCalledTimes(2);
+  await view.rerender({ isSynthesizing: true, playMode: "disabled" });
+  await fireEvent.click(view.getByRole("button", { name: "Stop" }));
+  expect(onAbort).toHaveBeenCalledTimes(1);
+});

--- a/src/lib/components/quick-settings.svelte
+++ b/src/lib/components/quick-settings.svelte
@@ -32,42 +32,37 @@
 </script>
 
 <!-- Compact settings panel for quick access to the most-used playback and listening controls -->
-<div class="border-border bg-card flex h-full flex-col gap-2 rounded-lg border p-3 shadow-sm">
+<div class="grid min-w-0 grid-cols-1 gap-x-6 sm:grid-cols-2 md:grid-cols-1">
   <!-- Show clipboard listener errors (e.g. permission denied, backend failure) -->
   {#if error}
     <p class="text-destructive text-xs">{error}</p>
   {/if}
   {#if config}
     <!-- Double-copy listener toggle — uses onchange (not bind) because state lives in the store, not config -->
-    <div
-      class="border-border bg-muted/30 flex items-center justify-between gap-2 rounded-lg border px-3 py-4"
-    >
+    <div class="border-border flex min-w-0 items-center justify-between gap-3 border-b py-3">
       <div class="flex items-center gap-1">
-        <Label for="listen-double-copy" class="text-xs">Listen</Label>
+        <Label for="listen-double-copy" class="text-sm">Double-copy</Label>
         <InfoTooltip text="Monitor clipboard for double-copy" />
       </div>
       <Switch id="listen-double-copy" checked={isListening} onchange={handleToggle} />
     </div>
     <!-- Global hotkey toggle — binds directly to config since it's a persistent preference -->
-    <div
-      class="border-border bg-muted/30 flex items-center justify-between gap-2 rounded-lg border px-3 py-4"
-    >
+    <div class="border-border flex min-w-0 items-center justify-between gap-3 border-b py-3">
       <div class="flex items-center gap-1">
-        <Label for="qs-hotkey" class="text-xs">Hotkey</Label>
-        <InfoTooltip text="Global hotkey to speak clipboard (default: Win+Shift+A)" />
+        <Label for="qs-hotkey" class="text-sm">Hotkey</Label>
+        <InfoTooltip text={config.hotkey.shortcut || "Speak clipboard with a keyboard shortcut"} />
       </div>
       <Switch id="qs-hotkey" bind:checked={config.hotkey.enabled} />
     </div>
     <!-- Effects toggle — binds to active profile's effects -->
-    <div
-      class="border-border bg-muted/30 flex items-center justify-between gap-2 rounded-lg border px-3 py-4"
-    >
+    <div class="border-border flex min-w-0 items-center justify-between gap-3 border-b py-3">
       <div class="flex items-center gap-1">
-        <Label for="qs-effects" class="text-xs">Effects</Label>
+        <Label for="qs-effects" class="text-sm">Effects</Label>
         <InfoTooltip text="Apply audio effect to TTS playback" />
       </div>
       <Switch
         id="qs-effects"
+        disabled={!activeProfile}
         checked={profileEffectsEnabled}
         onchange={() => {
           if (activeProfile) {
@@ -80,21 +75,22 @@
       />
     </div>
     <!-- Volume slider — 0–100% range with integer steps for precise control -->
-    <div class="border-border bg-muted/30 space-y-1 rounded-lg border px-3 py-4">
+    <div class="flex min-w-0 flex-col gap-3 py-3">
       <div class="flex items-center justify-between">
-        <Label for="qs-volume" class="text-xs">Volume</Label>
+        <Label for="qs-volume" class="text-sm">Volume</Label>
         <span class="text-muted-foreground text-xs">{config.playback.volume}%</span>
       </div>
       <Slider id="qs-volume" min={0} max={100} step={1} bind:value={config.playback.volume} />
     </div>
     <!-- Speed slider — reads from active profile -->
-    <div class="border-border bg-muted/30 space-y-1 rounded-lg border px-3 py-4">
+    <div class="flex min-w-0 flex-col gap-3 py-3">
       <div class="flex items-center justify-between">
-        <Label for="qs-speed" class="text-xs">Speed</Label>
+        <Label for="qs-speed" class="text-sm">Speed</Label>
         <span class="text-muted-foreground text-xs">{profileSpeed.toFixed(2)}x</span>
       </div>
       <Slider
         id="qs-speed"
+        disabled={!activeProfile}
         min={0.5}
         max={2}
         step={0.05}
@@ -105,13 +101,14 @@
       />
     </div>
     <!-- Pitch slider — reads from active profile -->
-    <div class="border-border bg-muted/30 space-y-1 rounded-lg border px-3 py-4">
+    <div class="flex min-w-0 flex-col gap-3 py-3">
       <div class="flex items-center justify-between">
-        <Label for="qs-pitch" class="text-xs">Pitch</Label>
+        <Label for="qs-pitch" class="text-sm">Pitch</Label>
         <span class="text-muted-foreground text-xs">{profilePitch.toFixed(2)}x</span>
       </div>
       <Slider
         id="qs-pitch"
+        disabled={!activeProfile}
         min={0.5}
         max={2}
         step={0.05}

--- a/src/lib/components/recent-history.svelte
+++ b/src/lib/components/recent-history.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { Button } from "$lib/components/ui/button/index.js";
-  import { Badge } from "$lib/components/ui/badge/index.js";
   import {
     AlertDialog,
     AlertDialogAction,
@@ -12,16 +12,20 @@
     AlertDialogTitle
   } from "$lib/components/ui/alert-dialog/index.js";
   import {
-    Play,
-    RotateCcw,
-    Trash2,
-    Clock,
-    ChevronDown,
-    ChevronUp,
-    ChevronRight
-  } from "@lucide/svelte";
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle
+  } from "$lib/components/ui/dialog/index.js";
+  import { Play, Square, Layers, Trash2, Clock } from "@lucide/svelte";
+  import { invoke } from "@tauri-apps/api/core";
+  import { Spinner } from "$lib/components/ui/spinner/index.js";
   import { historyStore } from "$lib/stores/history-store.svelte.js";
-  import type { HistoryItem } from "$lib/types";
+  import { playbackStore } from "$lib/stores/playback-store.svelte";
+  import { groupHistoryReadings, historyVoiceLabel } from "$lib/models/history";
+  import type { AppConfig, EngineCatalogEntry, VoiceProfile } from "$lib/types";
+  import { isTauri } from "$lib/services/tauri";
   import { _ } from "svelte-i18n";
 
   interface Props {
@@ -31,446 +35,222 @@
   }
 
   let { limit = 5, onSuccess, onError }: Props = $props();
-
+  type Reading = ReturnType<typeof groupHistoryReadings>[number];
   let actionInProgress = $state<string | null>(null);
-  let itemToDelete = $state<HistoryItem | null>(null);
-  let batchToDelete = $state<string | null>(null);
-  let expandedItems = $state<Set<string>>(new Set());
-  let expandedBatches = $state<Set<string>>(new Set());
+  let readingToDelete = $state<Reading | null>(null);
+  let selectedReading = $state<Reading | null>(null);
+  let actionError = $state<string | null>(null);
+  let profiles = $state<VoiceProfile[]>([]);
+  let engines = $state<EngineCatalogEntry[]>([]);
 
-  function toggleExpand(itemId: string) {
-    if (expandedItems.has(itemId)) {
-      expandedItems.delete(itemId);
-      expandedItems = new Set(expandedItems);
-    } else {
-      expandedItems = new Set(expandedItems.add(itemId));
-    }
-  }
-
-  function toggleBatchExpand(batchId: string) {
-    if (expandedBatches.has(batchId)) {
-      expandedBatches.delete(batchId);
-      expandedBatches = new Set(expandedBatches);
-    } else {
-      expandedBatches = new Set(expandedBatches.add(batchId));
-    }
-  }
-
-  interface GroupedItem {
-    type: "single";
-    item: HistoryItem;
-    timestamp: number;
-  }
-
-  interface GroupedBatch {
-    type: "batch";
-    batchId: string;
-    items: HistoryItem[];
-    timestamp: number;
-    tts_engine: string;
-    voice: string;
-    success: boolean;
-    totalFragments: number;
-  }
-
-  // Get recent items sorted descending by timestamp, grouped by batch_id
-  const recentGrouped = $derived(() => {
-    const sortedItems = [...historyStore.items].sort((a, b) => b.timestamp - a.timestamp);
-    const seenBatchIds = new Set<string>();
-    const result: Array<GroupedItem | GroupedBatch> = [];
-
-    for (const item of sortedItems) {
-      if (item.batch_id && !seenBatchIds.has(item.batch_id)) {
-        seenBatchIds.add(item.batch_id);
-        const batchItems = sortedItems.filter((i) => i.batch_id === item.batch_id);
-        const totalFragments = batchItems.length;
-        const firstItem = batchItems.reduce((a, b) => (a.timestamp < b.timestamp ? a : b));
-
-        result.push({
-          type: "batch",
-          batchId: item.batch_id,
-          items: batchItems.sort((a, b) => {
-            const idxA = (a.metadata?.fragment_index as number) ?? 0;
-            const idxB = (b.metadata?.fragment_index as number) ?? 0;
-            return idxA - idxB;
-          }),
-          timestamp: firstItem.timestamp,
-          tts_engine: item.tts_engine,
-          voice: item.voice,
-          success: batchItems.every((i) => i.success),
-          totalFragments
-        });
-      } else if (!item.batch_id) {
-        result.push({
-          type: "single",
-          item,
-          timestamp: item.timestamp
-        });
-      }
-    }
-
-    return result.sort((a, b) => b.timestamp - a.timestamp).slice(0, limit);
+  onMount(async () => {
+    if (!isTauri) return;
+    const [config, catalog] = await Promise.allSettled([
+      invoke<AppConfig>("get_config"),
+      invoke<EngineCatalogEntry[]>("list_tts_engines")
+    ]);
+    if (config.status === "fulfilled") profiles = config.value.tts.profiles;
+    else console.error("Failed to load history voice labels:", config.reason);
+    if (catalog.status === "fulfilled") engines = catalog.value;
+    else console.error("Failed to load history voice catalog:", catalog.reason);
   });
+  const readings = $derived(groupHistoryReadings(historyStore.items).slice(0, limit));
+  const playbackBusy = $derived(playbackStore.isPlaying || playbackStore.isSynthesizing);
 
-  async function handlePlay(item: HistoryItem) {
-    if (!item.output_path) {
-      await handleReSpeak(item);
-      return;
-    }
-
-    actionInProgress = item.id;
+  async function handlePlay(reading: Reading) {
+    actionInProgress = reading.id;
+    actionError = null;
     try {
-      await historyStore.playEntry(item.id);
+      if (playbackStore.historyReadingId === reading.id && playbackStore.isPlaying) {
+        playbackStore.handleStop();
+        await invoke("stop_speaking");
+        return;
+      }
+      if (playbackStore.isPlaying) {
+        playbackStore.handleStop();
+        await invoke("stop_speaking");
+      }
+      if (reading.batchId) await historyStore.playBatch(reading.batchId);
+      else await historyStore.playEntry(reading.items[0].id);
       onSuccess?.("Playing audio from history");
     } catch (e) {
-      onError?.(`Failed to play: ${e}`);
-    } finally {
-      actionInProgress = null;
-    }
-  }
-
-  async function handlePlayBatch(batchId: string) {
-    actionInProgress = batchId;
-    try {
-      await historyStore.playBatch(batchId);
-      onSuccess?.("Playing all fragments");
-    } catch (e) {
-      onError?.(`Failed to play batch: ${e}`);
-    } finally {
-      actionInProgress = null;
-    }
-  }
-
-  async function handleReSpeak(item: HistoryItem) {
-    actionInProgress = item.id;
-    try {
-      await historyStore.reSpeakEntry(item.id);
-      onSuccess?.("Re-synthesizing and playing");
-    } catch (e) {
-      onError?.(`Failed to re-speak: ${e}`);
+      actionError = `Failed to play: ${e}`;
+      onError?.(actionError);
     } finally {
       actionInProgress = null;
     }
   }
 
   async function confirmDelete() {
-    if (batchToDelete) {
-      actionInProgress = batchToDelete;
-      const bid = batchToDelete;
-      batchToDelete = null;
-      itemToDelete = null;
-      try {
-        await historyStore.deleteBatch(bid);
-        onSuccess?.("Deleted batch from history");
-      } catch (e) {
-        onError?.(`Failed to delete batch: ${e}`);
-      } finally {
-        actionInProgress = null;
-      }
-    } else if (itemToDelete) {
-      const item = itemToDelete;
-      itemToDelete = null;
-      actionInProgress = item.id;
-      try {
-        await historyStore.deleteItem(item.id);
-        onSuccess?.("Deleted from history");
-      } catch (e) {
-        onError?.(`Failed to delete: ${e}`);
-      } finally {
-        actionInProgress = null;
-      }
+    const reading = readingToDelete;
+    if (!reading) return;
+    readingToDelete = null;
+    actionInProgress = reading.id;
+    actionError = null;
+    try {
+      if (reading.batchId) await historyStore.deleteBatch(reading.batchId);
+      else await historyStore.deleteItem(reading.items[0].id);
+      onSuccess?.("Deleted from history");
+    } catch (e) {
+      actionError = `Failed to delete: ${e}`;
+      onError?.(actionError);
+    } finally {
+      actionInProgress = null;
     }
   }
 
-  function extractBatchInfo(item: HistoryItem): { position: number; total: number } | null {
-    if (
-      item.metadata &&
-      typeof item.metadata.fragment_index === "number" &&
-      typeof item.metadata.fragment_total === "number"
-    ) {
-      return {
-        position: (item.metadata.fragment_index as number) + 1,
-        total: item.metadata.fragment_total as number
-      };
-    }
-    const match = item.text.match(/\((\d+) of (\d+)\)\s*$/);
-    if (match) {
-      return { position: parseInt(match[1], 10), total: parseInt(match[2], 10) };
-    }
-    return null;
-  }
-
-  function formatSynthesisDuration(ms: number): string {
-    if (ms < 1000) return `${ms}ms`;
-    const seconds = ms / 1000;
-    if (seconds < 60) return `${seconds.toFixed(1)}s`;
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = (seconds % 60).toFixed(1);
-    return `${minutes}m ${remainingSeconds}s`;
-  }
-
-  function getSynthesisMs(item: HistoryItem): number | null {
-    if (item.metadata && typeof item.metadata.synthesis_ms === "number") {
-      return item.metadata.synthesis_ms as number;
-    }
-    return null;
-  }
-
-  function truncateText(text: string, maxLen: number): string {
-    if (text.length <= maxLen) return text;
-    return text.substring(0, maxLen - 3) + "...";
+  function formatDuration(ms: number) {
+    const seconds = Math.round(ms / 1000);
+    return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
   }
 </script>
 
-<div class="space-y-3">
-  <div class="flex items-center justify-between">
-    <h2 class="text-card-foreground flex items-center gap-2 font-medium">
-      <Clock class="h-4 w-4" />
-      {$_("history.title")}
-    </h2>
+<section class="flex min-w-0 flex-col gap-4" aria-labelledby="history-heading">
+  <div class="flex flex-wrap items-baseline justify-between gap-2">
+    <div>
+      <h2 id="history-heading" class="text-lg font-bold tracking-tight">{$_("history.title")}</h2>
+      <p class="text-muted-foreground text-sm">Your readings, ready to listen again.</p>
+    </div>
     {#if historyStore.isLoading}
-      <span class="text-muted-foreground text-xs">{$_("history.loading")}</span>
+      <span class="text-muted-foreground text-xs" role="status">{$_("history.loading")}</span>
     {/if}
   </div>
 
-  {#if recentGrouped().length === 0}
-    <p class="text-muted-foreground py-4 text-center text-sm italic">{$_("history.empty")}</p>
-  {:else}
-    <div class="space-y-2">
-      {#each recentGrouped() as grouped (grouped.type === "batch" ? grouped.batchId : grouped.item.id)}
-        {#if grouped.type === "single"}
-          {@const item = grouped.item}
-          <div
-            class="border-border bg-card hover:bg-accent/20 overflow-hidden rounded-lg border transition-colors"
-          >
-            <div
-              class="bg-muted/30 border-border/50 flex items-center justify-between gap-2 border-b px-3 py-2"
-            >
-              <div
-                class="text-muted-foreground flex min-w-0 items-center gap-1.5 overflow-hidden text-xs"
-              >
-                <span
-                  class="h-1.5 w-1.5 shrink-0 rounded-full {item.success
-                    ? 'bg-green-500'
-                    : 'bg-red-500'}"
-                ></span>
-                <span class="text-foreground shrink-0 font-medium">
-                  {item.output_path ? item.output_path.split(/[/\\]/).pop() : item.tts_engine}
-                </span>
-              </div>
-              <div class="flex shrink-0 items-center gap-0.5">
-                {#if getSynthesisMs(item)}
-                  <span class="text-muted-foreground mr-1 text-xs whitespace-nowrap">
-                    {formatSynthesisDuration(getSynthesisMs(item)!)}
-                  </span>
-                {/if}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="h-6 w-6"
-                  onclick={() => handlePlay(item)}
-                  disabled={actionInProgress === item.id}
-                  title={item.output_path ? $_("history.playSaved") : $_("history.reSynthesize")}
-                >
-                  <Play class="h-3 w-3" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="h-6 w-6"
-                  onclick={() => handleReSpeak(item)}
-                  disabled={actionInProgress === item.id}
-                  title={$_("history.reSynthesizeTooltip")}
-                >
-                  <RotateCcw class="h-3 w-3" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="h-6 w-6"
-                  onclick={() => (itemToDelete = item)}
-                  disabled={actionInProgress === item.id}
-                  title={$_("history.delete")}
-                >
-                  <Trash2 class="h-3 w-3" />
-                </Button>
-              </div>
-            </div>
-            <button
-              type="button"
-              class="relative w-full cursor-pointer text-left"
-              onclick={() => toggleExpand(item.id)}
-              title={expandedItems.has(item.id) ? "Click to collapse" : "Click to expand"}
-            >
-              <pre
-                class="text-card-foreground overflow-hidden px-3 py-2 pr-8 font-mono text-xs leading-relaxed whitespace-pre-wrap {expandedItems.has(
-                  item.id
-                )
-                  ? ''
-                  : 'line-clamp-1'}">
-{item.text}</pre>
-              <span
-                class="text-muted-foreground hover:text-foreground absolute right-2 bottom-1 rounded p-0.5 transition-colors"
-              >
-                {#if expandedItems.has(item.id)}
-                  <ChevronUp class="h-3 w-3" />
-                {:else}
-                  <ChevronDown class="h-3 w-3" />
-                {/if}
-              </span>
-            </button>
-          </div>
-        {:else}
-          {@const batch = grouped}
-          <div class="border-border bg-card overflow-hidden rounded-lg border transition-colors">
-            <button
-              type="button"
-              class="bg-muted/30 border-border/50 hover:bg-accent/10 flex w-full items-center justify-between gap-2 border-b px-3 py-2 text-left"
-              onclick={() => toggleBatchExpand(batch.batchId)}
-            >
-              <div class="flex min-w-0 items-center gap-1.5">
-                <ChevronRight
-                  class="h-3 w-3 shrink-0 transition-transform {expandedBatches.has(batch.batchId)
-                    ? 'rotate-90'
-                    : ''}"
-                />
-                <span
-                  class="h-1.5 w-1.5 shrink-0 rounded-full {batch.success
-                    ? 'bg-green-500'
-                    : 'bg-red-500'}"
-                ></span>
-                <span class="text-foreground shrink-0 text-xs font-medium">{batch.tts_engine}</span>
-                <Badge variant="secondary" class="h-4 shrink-0 px-1.5 py-0 text-[10px]">
-                  {$_("history.fragments", { values: { count: batch.totalFragments } })}
-                </Badge>
-              </div>
-              <div class="flex shrink-0 items-center gap-1">
-                <span class="text-muted-foreground text-xs">
-                  {new Date(batch.timestamp).toLocaleTimeString()}
-                </span>
-              </div>
-            </button>
-
-            {#if expandedBatches.has(batch.batchId)}
-              <div class="border-border/50 border-t">
-                <!-- Batch actions -->
-                <div
-                  class="bg-muted/10 border-border/30 flex items-center justify-between gap-2 border-b px-3 py-2"
-                >
-                  <span class="text-muted-foreground text-xs">
-                    {batch.voice}
-                  </span>
-                  <div class="flex shrink-0 items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      class="h-6 px-2 text-xs"
-                      onclick={(e) => {
-                        e.stopPropagation();
-                        handlePlayBatch(batch.batchId);
-                      }}
-                      disabled={actionInProgress === batch.batchId}
-                      title={$_("history.playAllTooltip")}
-                    >
-                      <Play class="mr-1 h-3 w-3" />
-                      {$_("history.playAll")}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      class="h-6 w-6"
-                      onclick={(e) => {
-                        e.stopPropagation();
-                        batchToDelete = batch.batchId;
-                      }}
-                      disabled={actionInProgress === batch.batchId}
-                      title={$_("history.deleteAllFragments")}
-                    >
-                      <Trash2 class="h-3 w-3" />
-                    </Button>
-                  </div>
-                </div>
-
-                <!-- Fragment list -->
-                <div class="max-h-64 overflow-y-auto">
-                  {#each batch.items as fragment (fragment.id)}
-                    {@const batchInfo = extractBatchInfo(fragment)}
-                    <div
-                      class="hover:bg-accent/10 border-border/30 flex items-center justify-between gap-2 border-b px-3 py-1.5 last:border-b-0"
-                    >
-                      <div class="flex min-w-0 flex-1 items-center gap-1.5">
-                        {#if batchInfo}
-                          <Badge variant="outline" class="h-4 shrink-0 px-1 text-[9px]">
-                            {batchInfo.position}/{batchInfo.total}
-                          </Badge>
-                        {/if}
-                        <span class="truncate text-xs">
-                          {truncateText(fragment.text, 60)}
-                        </span>
-                      </div>
-                      <div class="flex shrink-0 items-center gap-0.5">
-                        {#if getSynthesisMs(fragment)}
-                          <span class="text-muted-foreground mr-1 text-[10px]">
-                            {formatSynthesisDuration(getSynthesisMs(fragment)!)}
-                          </span>
-                        {/if}
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          class="h-5 w-5"
-                          onclick={(e) => {
-                            e.stopPropagation();
-                            handlePlay(fragment);
-                          }}
-                          disabled={actionInProgress === fragment.id || !fragment.output_path}
-                          title={fragment.output_path
-                            ? $_("history.playThisFragment")
-                            : $_("history.noAudioFile")}
-                        >
-                          <Play class="h-2.5 w-2.5" />
-                        </Button>
-                      </div>
-                    </div>
-                  {/each}
-                </div>
-              </div>
-            {/if}
-          </div>
-        {/if}
-      {/each}
+  {#if readings.length === 0 && !historyStore.isLoading}
+    <div class="text-muted-foreground flex flex-col items-center gap-3 py-12">
+      <Clock class="size-6" />
+      <p class="text-sm">{$_("history.empty")}</p>
     </div>
+  {:else}
+    <ul class="border-border divide-border divide-y border-y">
+      {#each readings as reading (reading.id)}
+        {@const item = reading.items[0]}
+        {@const isCurrent = playbackStore.historyReadingId === reading.id}
+        {@const isActive = isCurrent && playbackStore.isPlaying}
+        {@const actionLabel = isActive
+          ? $_("play.stop")
+          : isCurrent
+            ? $_("play.replay")
+            : $_("play.play")}
+        <li class="hover:bg-muted/40 flex min-w-0 items-start gap-3 px-2 py-4 transition-colors sm:px-3">
+          <Button
+            variant={isActive ? "secondary" : "outline"}
+            size="icon"
+            class="shrink-0"
+            onclick={() => handlePlay(reading)}
+            disabled={actionInProgress !== null || playbackStore.isSynthesizing || !reading.hasAudio}
+            aria-label={actionLabel}
+            title={isActive
+              ? actionLabel
+              : !reading.hasAudio
+                ? $_("history.noAudioFile")
+                : actionLabel}
+          >
+            {#if actionInProgress === reading.id}
+              <Spinner />
+            {:else if isActive}
+              <Square />
+            {:else}
+              <Play />
+            {/if}
+          </Button>
+          <div class="flex min-w-0 flex-1 flex-col gap-2">
+            <button
+              type="button"
+              class="focus-visible:ring-ring min-w-0 cursor-pointer rounded-sm text-left text-sm leading-relaxed focus-visible:ring-2 focus-visible:outline-none"
+              onclick={() => (selectedReading = reading)}
+              aria-label="Read full text"
+              aria-haspopup="dialog"
+              title="Read full text"
+            >
+              <span class="line-clamp-2 min-h-10 whitespace-pre-wrap wrap-anywhere"
+                >{reading.text}</span
+              >
+            </button>
+            <div class="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+              <time datetime={new Date(reading.timestamp).toISOString()}>
+                {new Date(reading.timestamp).toLocaleString(undefined, {
+                  dateStyle: "medium",
+                  timeStyle: "short"
+                })}
+              </time>
+              <span class="max-w-full truncate" title={`${item.tts_engine} · ${item.voice}`}
+                >{engines.find((engine) => engine.engine === item.tts_engine)?.label ??
+                  item.tts_engine} · {historyVoiceLabel(item, profiles, engines)}</span
+              >
+              {#if reading.durationMs > 0}
+                <span class="tabular-nums">{formatDuration(reading.durationMs)}</span>
+              {/if}
+              {#if reading.partCount > 1}
+                <span
+                  class="inline-flex items-center gap-1 whitespace-nowrap"
+                  title="Paginated reading; plays all saved parts in order"
+                >
+                  <Layers class="size-3" />
+                  {reading.partCount} parts
+                </span>
+              {/if}
+              {#if !reading.success}
+                <span class="text-destructive">Generation failed</span>
+              {:else if !reading.hasAudio}
+                <span>{$_("history.noAudioFile")}</span>
+              {/if}
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            class="shrink-0"
+            onclick={() => (readingToDelete = reading)}
+            disabled={actionInProgress !== null || playbackBusy}
+            aria-label={$_("history.delete")}
+            title={$_("history.delete")}
+          >
+            <Trash2 />
+          </Button>
+        </li>
+      {/each}
+    </ul>
   {/if}
 
-  {#if historyStore.error}
-    <p class="text-destructive text-sm">
-      {historyStore.error}
+  {#if actionError || historyStore.error || playbackStore.error}
+    <p class="text-destructive text-sm wrap-anywhere" role="alert">
+      {actionError || historyStore.error || playbackStore.error}
     </p>
   {/if}
-</div>
+</section>
+
+<Dialog
+  open={selectedReading !== null}
+  onOpenChange={(open) => {
+    if (!open) selectedReading = null;
+  }}
+>
+  <DialogContent class="flex max-h-[85dvh] min-w-0 flex-col sm:max-w-2xl">
+    <DialogHeader>
+      <DialogTitle>Reading text</DialogTitle>
+      <DialogDescription>
+        {selectedReading ? new Date(selectedReading.timestamp).toLocaleString() : ""}
+      </DialogDescription>
+    </DialogHeader>
+    <div class="min-h-0 overflow-y-auto text-sm leading-relaxed whitespace-pre-wrap wrap-anywhere">
+      {selectedReading?.text}
+    </div>
+  </DialogContent>
+</Dialog>
 
 <AlertDialog
-  open={!!(itemToDelete || batchToDelete)}
+  open={readingToDelete !== null}
   onOpenChange={(open) => {
-    if (!open) {
-      itemToDelete = null;
-      batchToDelete = null;
-    }
+    if (!open) readingToDelete = null;
   }}
 >
   <AlertDialogContent>
     <AlertDialogHeader>
-      <AlertDialogTitle
-        >{batchToDelete ? $_("history.deleteBatch") : $_("history.deleteEntry")}</AlertDialogTitle
+      <AlertDialogTitle>{$_("history.deleteEntry")}</AlertDialogTitle>
+      <AlertDialogDescription
+        >Delete this reading and all its saved audio? This cannot be undone.</AlertDialogDescription
       >
-      <AlertDialogDescription>
-        {#if batchToDelete}
-          {$_("history.deleteBatchDescription")}
-        {:else if itemToDelete?.output_path}
-          {$_("history.deleteEntryWithFile")}
-        {:else}
-          {$_("history.deleteEntryOnly")}
-        {/if}
-      </AlertDialogDescription>
     </AlertDialogHeader>
     <AlertDialogFooter>
       <AlertDialogCancel>{$_("history.cancel")}</AlertDialogCancel>

--- a/src/lib/components/settings-page.svelte
+++ b/src/lib/components/settings-page.svelte
@@ -215,14 +215,14 @@
       </div>
     </div>
   {:else if localConfig}
-    <div class="flex flex-row items-start gap-2">
+    <div class="flex min-w-0 flex-col items-stretch gap-4 md:flex-row md:items-start">
       <!-- Left Sidebar - Scroll Spy Navigation -->
-      <aside class="w-28 shrink-0 self-stretch">
+      <aside class="min-w-0 shrink-0 self-stretch md:w-28">
         <nav class="sticky top-0">
-          <div class="space-y-0.5">
+          <div class="flex flex-wrap gap-1 md:flex-col">
             {#each tabs as tab}
               <button
-                class="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors {activeTab ===
+                class="rounded-md px-2 py-1.5 text-left text-sm font-medium whitespace-nowrap transition-colors md:w-full {activeTab ===
                 tab.id
                   ? 'bg-primary/10 text-primary border-primary border-l-2'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"
@@ -236,13 +236,13 @@
       </aside>
 
       <!-- Main Content - Continuous Scroll -->
-      <main class="flex-1 space-y-6 pb-20">
+      <main class="min-w-0 flex-1 space-y-8 pb-20">
         <!-- General Section -->
         <section id="general" class="scroll-mt-4">
-          <div class="border-border overflow-hidden rounded-lg border">
+          <div class="border-border border-y">
             <div class="space-y-0">
               <!-- General -->
-              <div class="border-border border-b p-4">
+              <div class="border-border border-b py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.general")}
                 </h3>
@@ -293,7 +293,7 @@
               </div>
 
               <!-- Startup -->
-              <div class="border-border border-b p-4">
+              <div class="border-border border-b py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.startup")}
                 </h3>
@@ -301,7 +301,7 @@
               </div>
 
               <!-- Appearance -->
-              <div class="border-border border-b p-4">
+              <div class="border-border border-b py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.appearance")}
                 </h3>
@@ -309,7 +309,7 @@
               </div>
 
               <!-- Playback -->
-              <div class="border-border border-b p-4">
+              <div class="py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.playback")}
                 </h3>
@@ -321,9 +321,9 @@
 
         <!-- History Section -->
         <section id="history" class="scroll-mt-4">
-          <div class="border-border overflow-hidden rounded-lg border">
+          <div class="border-border border-y">
             <div class="space-y-0">
-              <div class="p-4">
+              <div class="py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.history")}
                 </h3>
@@ -335,10 +335,10 @@
 
         <!-- Advanced Section -->
         <section id="advanced" class="scroll-mt-4">
-          <div class="border-border overflow-hidden rounded-lg border">
+          <div class="border-border border-y">
             <div class="space-y-0">
               <!-- Advanced -->
-              <div class="border-border border-b p-4">
+              <div class="border-border border-b py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.pagination")}
                 </h3>
@@ -347,7 +347,7 @@
               </div>
 
               <!-- Sanitization -->
-              <div class="border-border border-b p-4">
+              <div class="border-border border-b py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.sanitization")}
                 </h3>
@@ -355,7 +355,7 @@
               </div>
 
               <!-- LLM Post-Processing -->
-              <div class="p-4">
+              <div class="py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.postProcess")}
                 </h3>
@@ -367,10 +367,10 @@
 
         <!-- About Section -->
         <section id="about" class="scroll-mt-4">
-          <div class="border-border overflow-hidden rounded-lg border">
+          <div class="border-border border-y">
             <div class="space-y-0">
               <!-- App Info -->
-              <div class="border-border border-b p-4">
+              <div class="border-border border-b py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.appInfo")}
                 </h3>
@@ -378,7 +378,7 @@
               </div>
 
               <!-- Import / Export -->
-              <div class="p-4">
+              <div class="py-4">
                 <h3 class="text-muted-foreground mb-3 text-sm font-medium">
                   {$_("settings.sections.importExport")}
                 </h3>

--- a/src/lib/components/ui/setting-row/setting-row.svelte
+++ b/src/lib/components/ui/setting-row/setting-row.svelte
@@ -14,14 +14,14 @@
   } = $props();
 </script>
 
-<div class="flex min-h-9 items-center justify-between gap-x-4 py-1">
-  <div class="flex items-center gap-1.5">
+<div class="flex min-h-9 min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 py-2">
+  <div class="flex min-w-0 items-center gap-1.5">
     <Label>{label}</Label>
     {#if tooltip}
       <InfoTooltip text={tooltip} />
     {/if}
   </div>
-  <div class="flex shrink-0 items-center justify-end">
+  <div class="flex min-w-0 max-w-full items-center justify-end [&>*]:max-w-full">
     {@render children()}
   </div>
 </div>

--- a/src/lib/models/history.test.ts
+++ b/src/lib/models/history.test.ts
@@ -1,0 +1,84 @@
+import { expect, it } from "vitest";
+import { createHistoryItem, groupHistoryReadings, historyVoiceLabel } from "./history";
+import type { EngineCatalogEntry, VoiceProfile } from "$lib/types";
+
+it("uses matching voice labels without confusing engine IDs or exposing unknown IDs", () => {
+  const item = createHistoryItem("Hello", "cartesia", "voice-id", 1);
+  const profile: VoiceProfile = {
+    id: "profile",
+    name: "Reading",
+    description: null,
+    engine: "cartesia",
+    voice: "voice-id",
+    voice_label: "Katie",
+    speed: 1,
+    pitch: 1,
+    effects: { enabled: false, active_effect: "none" },
+    engine_options: {}
+  };
+  const engine: EngineCatalogEntry = {
+    engine: "cartesia",
+    label: "Cartesia",
+    description: "",
+    docs_url: "",
+    supports_voice_refresh: false,
+    supports_pitch: false,
+    supports_bracket_emotes: false,
+    options: [],
+    voices: [
+      {
+        id: "voice-id",
+        label: "Catalog Katie",
+        language: null,
+        description: null,
+        gender: null,
+        preview_url: null
+      }
+    ]
+  };
+  expect(historyVoiceLabel(item, [profile], [engine])).toBe("Katie");
+  expect(historyVoiceLabel(item, [], [engine])).toBe("Catalog Katie");
+  expect(historyVoiceLabel(item, [{ ...profile, engine: "openai" }], [])).toBe("Saved voice");
+  expect(historyVoiceLabel(item, [], [])).toBe("Saved voice");
+  expect(item.voice).toBe("voice-id");
+});
+
+it("presents fragments as one ordered reading without mutating source history", () => {
+  const first = createHistoryItem("First", "openai", "alloy", 1, {
+    id: "first",
+    timestamp: 10,
+    batch_id: "reading",
+    success: true,
+    output_path: "first.wav",
+    duration_ms: 1000,
+    metadata: { fragment_index: 0, fragment_total: 3 }
+  });
+  const last = createHistoryItem("Last", "openai", "alloy", 1, {
+    id: "last",
+    timestamp: 30,
+    batch_id: "reading",
+    success: false,
+    metadata: { fragment_index: 1, fragment_total: 3 }
+  });
+  const single = createHistoryItem("Single", "openai", "alloy", 1, {
+    id: "reading",
+    timestamp: 20,
+    success: true,
+    output_path: "single.wav"
+  });
+  const items = [last, single, first];
+  const readings = groupHistoryReadings(items);
+  expect(readings.map((reading) => reading.text)).toEqual(["Single", "First\n\nLast"]);
+  expect(readings[1]).toMatchObject({
+    batchId: "reading",
+    partCount: 3,
+    timestamp: 10,
+    durationMs: 1000,
+    success: false,
+    hasAudio: false
+  });
+  expect(readings[0].hasAudio).toBe(true);
+  expect(readings[0].partCount).toBe(1);
+  expect(items.map((item) => item.id)).toEqual(["last", "reading", "first"]);
+  expect(groupHistoryReadings([])).toEqual([]);
+});

--- a/src/lib/models/history.ts
+++ b/src/lib/models/history.ts
@@ -15,6 +15,60 @@ import type {
   AudioFormat,
   TtsEngine
 } from "$lib/types";
+import type { EngineCatalogEntry, VoiceProfile } from "$lib/types";
+
+export function historyVoiceLabel(
+  item: HistoryItem,
+  profiles: VoiceProfile[],
+  engines: EngineCatalogEntry[]
+): string {
+  const profile = profiles.find(
+    (profile) =>
+      profile.engine === item.tts_engine &&
+      profile.voice === item.voice &&
+      profile.voice_label?.trim()
+  );
+  const catalogVoice = engines
+    .find((engine) => engine.engine === item.tts_engine)
+    ?.voices.find((voice) => voice.id === item.voice);
+  return profile?.voice_label?.trim() || catalogVoice?.label.trim() || "Saved voice";
+}
+
+/** One reading per row, regardless of how many audio files synthesis produced. */
+export function groupHistoryReadings(items: HistoryItem[]) {
+  const groups = new Map<string, HistoryItem[]>();
+  for (const item of items) {
+    const key = item.batch_id ? `batch:${item.batch_id}` : `entry:${item.id}`;
+    const group = groups.get(key);
+    if (group) group.push(item);
+    else groups.set(key, [item]);
+  }
+  return [...groups.entries()]
+    .map(([id, entries]) => {
+      entries.sort((a, b) => {
+        const aIndex = a.metadata?.fragment_index;
+        const bIndex = b.metadata?.fragment_index;
+        return typeof aIndex === "number" && typeof bIndex === "number"
+          ? aIndex - bIndex
+          : a.timestamp - b.timestamp;
+      });
+      return {
+        id,
+        items: entries,
+        batchId: entries[0].batch_id,
+        partCount: entries.reduce((total, item) => {
+          const expected = item.metadata?.fragment_total;
+          return typeof expected === "number" ? Math.max(total, expected) : total;
+        }, entries.length),
+        text: entries.map((item) => item.text).join("\n\n"),
+        timestamp: entries.reduce((earliest, item) => Math.min(earliest, item.timestamp), Infinity),
+        success: entries.every((item) => item.success),
+        hasAudio: entries.every((item) => !!item.output_path),
+        durationMs: entries.reduce((total, item) => total + (item.duration_ms ?? 0), 0)
+      };
+    })
+    .sort((a, b) => b.timestamp - a.timestamp);
+}
 
 /**
  * Creates a new history item with default values

--- a/src/lib/stores/history-store.svelte.ts
+++ b/src/lib/stores/history-store.svelte.ts
@@ -56,6 +56,7 @@ function backendToHistoryItem(entry: BackendHistoryEntry): HistoryItem {
  */
 
 import type { HistoryItem, HistoryState, HistoryFilters, HistorySortOptions } from "$lib/types";
+import { playbackStore } from "./playback-store.svelte";
 import {
   createEmptyHistoryState,
   filterHistoryItems,
@@ -295,8 +296,10 @@ function createHistoryStore() {
           audioDurationMs: item.duration_ms ?? null
         }).catch(() => {});
       }
+      playbackStore.historyReadingId = `entry:${id}`;
       await invoke("play_history_entry", { entryId: id });
     } catch (e) {
+      playbackStore.historyReadingId = null;
       throw new Error(`Failed to play entry: ${e}`);
     }
   }
@@ -360,8 +363,10 @@ function createHistoryStore() {
     }
 
     try {
+      playbackStore.historyReadingId = `batch:${batchId}`;
       await invoke("play_history_batch", { batchId });
     } catch (e) {
+      playbackStore.historyReadingId = null;
       throw new Error(`Failed to play batch: ${e}`);
     }
   }

--- a/src/lib/stores/playback-store.svelte.ts
+++ b/src/lib/stores/playback-store.svelte.ts
@@ -11,16 +11,9 @@
 
 import { isTauri } from "$lib/services/tauri.js";
 import type { EffectId } from "$lib/types";
-import {
-  applyFadeIn,
-  audioBufferToWavBlob,
-  detectAudioMimeType
-} from "./playback/audio-utils.js";
+import { applyFadeIn, audioBufferToWavBlob, detectAudioMimeType } from "./playback/audio-utils.js";
 import { AudioAnalyser } from "./playback/analyser.js";
-import {
-  PcmStreamScheduler,
-  type StreamChunkPayload
-} from "./playback/pcm-stream.js";
+import { PcmStreamScheduler, type StreamChunkPayload } from "./playback/pcm-stream.js";
 import { getEffect } from "./playback/effects/registry.js";
 import { FragmentQueue, type QueuedFragment } from "./playback/fragment-queue.js";
 import { hudStore } from "./hud-store.svelte.js";
@@ -31,6 +24,8 @@ class PlaybackStore {
   isSynthesizing = $state(false);
   error = $state<string | null>(null);
   hasCachedAudio = $state(false);
+  // Retained after stop/completion so the owning history row can offer Replay.
+  historyReadingId = $state<string | null>(null);
 
   // Pagination state for HUD display
   currentFragmentIndex = $state<number | null>(null);
@@ -271,10 +266,7 @@ class PlaybackStore {
       void ctx.resume();
     }
     if (!this._pcmScheduler) {
-      console.log(
-        "[PlaybackStore] creating PCM scheduler for fragment",
-        payload.fragment_index
-      );
+      console.log("[PlaybackStore] creating PCM scheduler for fragment", payload.fragment_index);
       this._pcmScheduler = new PcmStreamScheduler({
         ctx,
         destination: ctx.destination,
@@ -314,6 +306,7 @@ class PlaybackStore {
   }
 
   async handleReplay(): Promise<void> {
+    this.historyReadingId = null;
     if (!this._audioEl) return;
     const url = await this.buildPlaybackUrl(this.pitch);
     if (url) {
@@ -437,12 +430,9 @@ class PlaybackStore {
       });
 
       // Streaming PCM chunks from streaming-capable backends (ElevenLabs)
-      const unStreamChunk = await listen<StreamChunkPayload>(
-        "audio-stream-chunk",
-        (e) => {
-          this.handleStreamChunk(e.payload);
-        }
-      );
+      const unStreamChunk = await listen<StreamChunkPayload>("audio-stream-chunk", (e) => {
+        this.handleStreamChunk(e.payload);
+      });
 
       // Authoritative end-of-synthesis signal for the streamed queue; the
       // scheduler completes once all scheduled sources have drained.
@@ -461,6 +451,7 @@ class PlaybackStore {
       });
 
       const unSynthesis = await listen<boolean>("synthesis-state-change", (e) => {
+        if (e.payload) this.historyReadingId = null;
         this.isSynthesizing = e.payload;
       });
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -216,7 +216,9 @@
 
   <TooltipProvider delayDuration={300}>
     <div
-      class="bg-background grid h-screen grid-rows-[auto_1fr_auto] overflow-hidden"
+      class="bg-background grid h-dvh min-w-0 overflow-hidden {isOnboarding
+        ? 'grid-rows-[minmax(0,1fr)]'
+        : 'grid-rows-[auto_minmax(0,1fr)_auto]'}"
       dir={$isRtl ? "rtl" : "ltr"}
     >
       {#if !isOnboarding}
@@ -224,9 +226,11 @@
       {/if}
 
       <main
-        class={isOnboarding ? "w-full overflow-y-auto" : "w-full overflow-y-auto px-4 py-6 sm:px-6"}
+        class={isOnboarding
+          ? "min-h-0 min-w-0 overflow-auto"
+          : "min-h-0 min-w-0 overflow-auto px-4 py-4 sm:px-6"}
       >
-        <MotionWrapper>
+        <MotionWrapper class="min-h-full min-w-0 flex flex-col">
           {@render children()}
         </MotionWrapper>
       </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
   <Screenshots />
   <Footer />
 {:else}
-  <div class="mx-auto flex min-h-0 max-w-6xl flex-1 flex-col">
+  <div class="mx-auto flex w-full min-w-0 max-w-6xl flex-1 flex-col">
     <PlayPage />
   </div>
 {/if}

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -4,6 +4,7 @@
   import { invoke } from "@tauri-apps/api/core";
   import { toast } from "svelte-sonner";
   import { Button } from "$lib/components/ui/button/index.js";
+  import { Input } from "$lib/components/ui/input/index.js";
 
   import type { AppConfig } from "$lib/types";
   import { Volume2 } from "@lucide/svelte";
@@ -18,10 +19,9 @@
     isLoading = true;
     try {
       const config = await invoke<AppConfig>("get_config");
-      config.tts.active_backend = "edge";
-      if (config.tts.edge) {
-        config.tts.edge.voice = "en-US-AvaMultilingualNeural";
-      }
+      const cartesiaProfile = config.tts.profiles.find((profile) => profile.engine === "cartesia");
+      config.tts.active_backend = "cartesia";
+      if (cartesiaProfile) config.tts.active_profile_id = cartesiaProfile.id;
       config.pagination.fragment_size = 500;
       localConfig = config;
     } catch (e) {
@@ -32,17 +32,18 @@
     }
   }
 
-  async function testEdgeTts() {
+  async function testCartesia() {
+    if (!localConfig) return;
     testing = true;
     try {
-      const result = await invoke<{ success: boolean; message: string }>("test_tts_engine_config", {
-        engine: "edge",
-        preset: null
-      });
-      if (result.success) toast.success(result.message || "Edge-TTS is working.");
-      else toast.error(result.message || "Edge-TTS test failed.");
+      await invoke("set_config", { newConfig: localConfig });
+      const result = await invoke<{ success: boolean; message: string }>(
+        "check_cartesia_credentials"
+      );
+      if (result.success) toast.success(result.message || "Cartesia is ready.");
+      else toast.error(result.message || "Cartesia API key check failed.");
     } catch (e) {
-      toast.error(`Edge-TTS test failed: ${e}`);
+      toast.error(`Cartesia API key check failed: ${e}`);
     } finally {
       testing = false;
     }
@@ -81,17 +82,12 @@
   onMount(loadDefaultConfig);
 </script>
 
-<div
-  class="from-background to-muted/30 flex min-h-screen items-center justify-center bg-linear-to-br p-4 sm:p-6"
->
+<div class="bg-background flex min-h-screen items-center justify-center p-4 sm:p-8">
   <div class="w-full max-w-2xl">
-    <!-- Main Card -->
-    <div class="border-border bg-card space-y-6 rounded-lg border p-6 shadow-lg sm:p-8">
+    <div class="space-y-6">
       <!-- Header -->
-      <div class="space-y-2 text-center">
-        <h1
-          class="from-foreground to-foreground/70 bg-linear-to-r bg-clip-text font-mono text-3xl font-bold tracking-tight sm:text-4xl"
-        >
+      <div class="space-y-2">
+        <h1 class="text-3xl font-bold tracking-tight sm:text-4xl">
           {$_("onboarding.welcome.title")}
         </h1>
         <p class="text-muted-foreground text-sm sm:text-base">
@@ -105,20 +101,30 @@
           <div class="text-muted-foreground">{$_("onboarding.loading")}</div>
         </div>
       {:else if localConfig}
-        <div class="border-border space-y-5 border-t border-b py-6">
-          <div class="rounded-lg border border-sky-500/30 bg-sky-500/8 p-5">
+        <div class="border-border space-y-5 border-y py-6">
+          <div class="p-1">
             <div class="flex items-start gap-3">
-              <div class="rounded-md bg-sky-500/15 p-2 text-sky-700 dark:text-sky-300">
+              <div class="bg-primary/10 text-primary rounded-sm p-2">
                 <Volume2 class="h-5 w-5" />
               </div>
               <div class="space-y-1">
-                <h2 class="font-mono text-lg font-semibold">Ready to go with Edge-TTS</h2>
+                <h2 class="text-lg font-semibold">Set up Cartesia</h2>
                 <p class="text-muted-foreground text-sm leading-relaxed">
                   CopySpeak is set to Cartesia by default for fast, high-quality speech. Paste your
                   API key, verify it without spending synthesis credits, then start listening.
                 </p>
               </div>
             </div>
+            <label for="cartesia-api-key" class="mt-5 block text-sm font-medium">
+              Cartesia API key
+            </label>
+            <Input
+              id="cartesia-api-key"
+              type="password"
+              bind:value={localConfig.tts.cartesia.api_key}
+              placeholder="sk_car_…"
+              class="mt-2"
+            />
           </div>
         </div>
 
@@ -127,8 +133,8 @@
           <Button
             variant="outline"
             size="lg"
-            onclick={testEdgeTts}
-            disabled={testing}
+            onclick={testCartesia}
+            disabled={testing || !localConfig.tts.cartesia.api_key.trim()}
             class="flex-1"
           >
             {testing ? "Testing…" : "Test"}


### PR DESCRIPTION
## Summary

- make the main window and app shell responsive down to the supported minimum size
- flatten Play, History, Voices, Engines, Settings, and Onboarding into a consistent layout
- group history fragments into readings with full-reading playback, takeover controls, resolved voice labels, and padded rows
- make Cartesia the fresh-install default and validate its API key during onboarding

## Validation

- `bun run check` — 0 errors and 0 warnings
- `bun run test` — 32 tests passed
- `cargo test test_default_tts_config_uses_cartesia_profile` — passed

## Known existing findings

- Vitest still reports the obsolete inline `hot` option
- the separate Svelte analyzer still reports existing route-resolution, unkeyed-loop, and profile-manager rune suggestions