### PR TITLE
feat(ui): recent history rail, playback recovery (v0.1.15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 
 ## Active failure log
 
+- Update `play-page.svelte`'s browser mock config when adding required `AppConfig` fields, matching backend defaults.
 - Present history batches as one reading in `recent-history.svelte`; preserve fragment order for full text, playback, and whole-reading deletion.
 - Show pagination as a part count on history rows; keep Play/Stop/Replay on the reading's button instead of adding a lower playback bar.
 - Resolve history voice labels by both engine and voice ID using profiles/catalog; retain raw IDs for playback and tooltips.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,15 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 ## Active failure log
 
 - Update `play-page.svelte`'s browser mock config when adding required `AppConfig` fields, matching backend defaults.
+- Treat `git diff --check` as a check; do not run it before explicit confirmation.
 - Present history batches as one reading in `recent-history.svelte`; preserve fragment order for full text, playback, and whole-reading deletion.
 - Show pagination as a part count on history rows; keep Play/Stop/Replay on the reading's button instead of adding a lower playback bar.
 - Resolve history voice labels by both engine and voice ID using profiles/catalog; retain raw IDs for playback and tooltips.
 - Hide the playback button's decorative spinner from accessibility naming so synthesis keeps the action named “Stop”.
+- Clear the shared audio queue on decode/play failure and invalidate pending decoding on Stop so history retries work and stopped readings cannot restart.
+- Translate vertical mouse-wheel input into horizontal scrolling on the Play history rail, and end its five-reading preview with a link to full History.
+- Keep the wheel-driven history rail free of scroll snapping and reverse wheel deltas in RTL; DOM-only tests cannot verify browser snapping behavior.
+- Close the History-only Delete conditional inside its reading row, before `</li>`; do not place its closing block in the View more card.
 
 <!-- rtk-instructions v2 -->
 ## RTK (Rust Token Killer) - Token-Optimized Commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15] - 2026-09-06
+
+### Added
+
+- **Recent history on the Play page** — a compact history rail below the reader shows the five most recent readings (when history is enabled), with a link to full History. Vertical mouse-wheel input scrolls the rail horizontally; the five-reading preview ends with a "View all in History" link.
+- **Relative time labels in history** — readings show "Just now", "15 min ago", etc. via a locale-aware `historyTimeAgo` formatter.
+- **Reading pagination count on history rows** — multi-part readings show a part count so a batched reading is distinguishable at a glance.
+- **History-only Delete action** — delete a single reading from its History row (with confirmation), without touching playback controls.
+- New tests for the recent history component and the playback store.
+
+### Changed
+
+- **Tighter Play page layout** — smaller side rail, visually hidden reader heading, denser spacing.
+
+### Fixed
+
+- **Audio queue recovery** — clear the shared audio queue on decode/play failure and invalidate pending decoding on Stop, so failed readings can be retried and stopped readings cannot restart.
+- **History recording filenames** — more compact minute-key naming for saved audio files.
+
 ## [0.1.14] - 2026-09-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CopySpeak",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A simple and configurable AI-generated Text-to-Speech (TTS) orchestrator for Windows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copyspeak"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "CopySpeak - AI text-to-speech orchestrator"
 

--- a/src-tauri/src/commands/tts/synthesis.rs
+++ b/src-tauri/src/commands/tts/synthesis.rs
@@ -359,7 +359,14 @@ async fn speak_now_internal(
     // Enter critical section for TTS synthesis
     let _synthesis_guard = SynthesisGuard::new(&app);
 
-    let (active_backend, tts_config, output_config, pagination_config, post_process_config) = {
+    let (
+        active_backend,
+        tts_config,
+        output_config,
+        pagination_config,
+        post_process_config,
+        streaming_enabled,
+    ) = {
         let cfg = config.lock().unwrap();
         (
             cfg.tts.active_backend.clone(),
@@ -367,6 +374,7 @@ async fn speak_now_internal(
             cfg.output.clone(),
             cfg.pagination.clone(),
             cfg.post_process.clone(),
+            cfg.playback.streaming_enabled,
         )
     };
 
@@ -433,8 +441,10 @@ async fn speak_now_internal(
     // Streaming backends forward PCM chunks during synthesis in playback mode;
     // batch backends (and cache hits / file output / pagination) take the
     // untouched existing branches.
-    let streaming_playback =
-        backend_arc.supports_streaming() && cached_path.is_none() && !output_config.enabled;
+    let streaming_playback = streaming_enabled
+        && backend_arc.supports_streaming()
+        && cached_path.is_none()
+        && !output_config.enabled;
     let (wav_bytes, already_streamed) = if let Some(ref path) = cached_path {
         // Try to read cached audio
         match std::fs::read(path) {
@@ -742,13 +752,14 @@ pub async fn speak_queued(
         return Err("Nothing to speak".into());
     }
 
-    let (active_backend, tts_config, pagination_config, post_process_config) = {
+    let (active_backend, tts_config, pagination_config, post_process_config, streaming_enabled) = {
         let cfg = config.lock().unwrap();
         (
             cfg.tts.active_backend.clone(),
             cfg.tts.clone(),
             cfg.pagination.clone(),
             cfg.post_process.clone(),
+            cfg.playback.streaming_enabled,
         )
     };
 
@@ -894,7 +905,7 @@ pub async fn speak_queued(
         // Synthesize fragment — streaming-capable backends forward PCM chunks
         // as they arrive; batch backends take the untouched synthesize path.
         let fragment_start = Instant::now();
-        let streamed = backend_arc.supports_streaming();
+        let streamed = streaming_enabled && backend_arc.supports_streaming();
         let wav_bytes = if streamed {
             synthesize_streaming_and_emit(
                 &app,

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -211,6 +211,7 @@ impl Default for AppConfig {
             playback: PlaybackConfig {
                 on_retrigger: RetriggerMode::Queue,
                 volume: 100,
+                streaming_enabled: true,
                 playback_speed: 1.0,
                 pitch: 1.0,
             },

--- a/src-tauri/src/config/playback.rs
+++ b/src-tauri/src/config/playback.rs
@@ -15,6 +15,8 @@ pub struct PlaybackConfig {
     pub on_retrigger: RetriggerMode,
     #[serde(default = "default_volume")]
     pub volume: u8,
+    #[serde(default = "default_streaming_enabled")]
+    pub streaming_enabled: bool,
     // Legacy fields — kept for deserialization during v2→v3 migration,
     // then skipped on serialize.
     #[serde(default = "default_playback_speed", skip_serializing)]
@@ -25,6 +27,10 @@ pub struct PlaybackConfig {
 
 fn default_volume() -> u8 {
     100
+}
+
+fn default_streaming_enabled() -> bool {
+    true
 }
 
 fn default_playback_speed() -> f32 {

--- a/src-tauri/src/config/tests.rs
+++ b/src-tauri/src/config/tests.rs
@@ -3,6 +3,22 @@ mod tests {
     use crate::config::*;
 
     #[test]
+    fn streaming_setting_defaults_on_and_persists_when_disabled() {
+        let mut config = serde_json::to_value(AppConfig::default()).unwrap();
+        assert_eq!(config["playback"]["streaming_enabled"], true);
+        config["playback"]
+            .as_object_mut()
+            .unwrap()
+            .remove("streaming_enabled");
+        let mut restored: AppConfig = serde_json::from_value(config).unwrap();
+        assert!(restored.playback.streaming_enabled);
+        restored.playback.streaming_enabled = false;
+        let saved = serde_json::to_string(&restored).unwrap();
+        let restored: AppConfig = serde_json::from_str(&saved).unwrap();
+        assert!(!restored.playback.streaming_enabled);
+    }
+
+    #[test]
     fn test_expand_filename_pattern_timestamp() {
         let result = expand_filename_pattern("output_{timestamp}.wav", "af_heart", "hello");
         assert!(result.starts_with("output_"));

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -962,7 +962,7 @@ pub fn save_audio_to_storage(
     let _ = std::fs::create_dir_all(&dir);
 
     let now = chrono::Local::now();
-    let minute_key = now.format("%Y-%m-%d-%H-%M").to_string();
+    let minute_key = now.format("%y%m%d-%H%M").to_string();
     let count = config::get_and_increment_minute_counter(&minute_key);
     let filename = if count == 1 {
         format!(

--- a/src-tauri/src/tts/cartesia.rs
+++ b/src-tauri/src/tts/cartesia.rs
@@ -1,3 +1,4 @@
+use super::stream::{AudioFormatMeta, ChunkItem, ChunkStream};
 use super::{TtsBackend, TtsError};
 use crate::config::CartesiaConfig;
 use reqwest::Client;
@@ -35,6 +36,72 @@ pub struct CartesiaTtsBackend {
 impl CartesiaTtsBackend {
     pub fn new(config: CartesiaConfig) -> Self {
         Self { config }
+    }
+
+    fn synthesize_streaming_from(
+        &self,
+        url: &str,
+        text: &str,
+        voice: &str,
+    ) -> Result<ChunkStream, TtsError> {
+        let api_key = crate::secrets::resolve(&self.config.api_key, &["CARTESIA_API_KEY"]);
+        if api_key.trim().is_empty() {
+            return Err(TtsError::Unavailable("Cartesia API key is missing".into()));
+        }
+        // The shared player and history WAV writer consume signed integer PCM.
+        let body = json!({
+            "model_id": self.config.model_id,
+            "transcript": text,
+            "voice": { "mode": "id", "id": voice },
+            "output_format": {
+                "container": "raw",
+                "encoding": "pcm_s16le",
+                "sample_rate": 44100,
+            },
+        });
+        let url = url.to_owned();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            Self::block_on_async(async move {
+                let result: Result<(), TtsError> = async {
+                    let mut response = Client::new()
+                        .post(url)
+                        .header("X-API-Key", api_key)
+                        .header("Cartesia-Version", CARTESIA_VERSION)
+                        .json(&body)
+                        .send()
+                        .await
+                        .map_err(|e| TtsError::Http(format!("Cartesia stream request failed: {e}")))?;
+                    let status = response.status();
+                    if !status.is_success() {
+                        let error_text = response.text().await.unwrap_or_default();
+                        return Err(TtsError::Http(format!("Cartesia API error {status}: {error_text}")));
+                    }
+                    let mut total_bytes = 0usize;
+                    while let Some(chunk) = response.chunk().await.map_err(|e| {
+                        TtsError::Http(format!("Cartesia stream read failed after {total_bytes} bytes: {e}"))
+                    })? {
+                        if chunk.is_empty() {
+                            continue;
+                        }
+                        total_bytes += chunk.len();
+                        if tx.send(ChunkItem::Pcm(chunk.to_vec())).is_err() {
+                            return Ok(());
+                        }
+                    }
+                    Ok(())
+                }.await;
+                if let Err(error) = result {
+                    log::error!("[TTS] {error}");
+                    let _ = tx.send(ChunkItem::Failed(error.to_string()));
+                }
+            });
+        });
+        Ok(ChunkStream::new(AudioFormatMeta {
+            sample_rate: 44100,
+            channels: 1,
+            bits_per_sample: 16,
+        }, rx))
     }
 
     fn block_on_async<F, T>(f: F) -> T
@@ -92,6 +159,14 @@ impl CartesiaTtsBackend {
 impl TtsBackend for CartesiaTtsBackend {
     fn name(&self) -> &str {
         "Cartesia"
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn synthesize_streaming(&self, text: &str, voice: &str) -> Result<ChunkStream, TtsError> {
+        self.synthesize_streaming_from(CARTESIA_TTS_URL, text, voice)
     }
 
     fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>, TtsError> {
@@ -193,5 +268,108 @@ impl TtsBackend for CartesiaTtsBackend {
                 .map(|v| v.label)
                 .unwrap_or_else(|| "Voice".to_string())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::time::Duration;
+
+    #[test]
+    fn streams_before_response_finishes_and_reports_truncated_body() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/tts/bytes", listener.local_addr().unwrap());
+        let (release, wait) = std::sync::mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut socket, _) = listener.accept().unwrap();
+            socket.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0];
+            while !request.ends_with(b"\r\n\r\n") {
+                socket.read_exact(&mut byte).unwrap();
+                request.push(byte[0]);
+            }
+            let headers = String::from_utf8(request).unwrap().to_lowercase();
+            assert!(headers.starts_with("post /tts/bytes http/1.1"));
+            assert!(headers.contains("x-api-key: test-key\r\n"));
+            assert!(headers.contains(&format!("cartesia-version: {CARTESIA_VERSION}\r\n")));
+            let length: usize = headers.lines()
+                .find_map(|line| line.strip_prefix("content-length: "))
+                .unwrap().parse().unwrap();
+            let mut body = vec![0; length];
+            socket.read_exact(&mut body).unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(body["transcript"], "hello");
+            assert_eq!(body["model_id"], "test-model");
+            assert_eq!(body["voice"]["id"], "requested-voice");
+            assert_eq!(body["output_format"], json!({
+                "container": "raw", "encoding": "pcm_s16le", "sample_rate": 44100,
+            }));
+            // Advertise more bytes than we send, to exercise mid-body failure.
+            socket.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\n\x01\x02").unwrap();
+            socket.flush().unwrap();
+            // The client must receive audio while this response is still open.
+            wait.recv_timeout(Duration::from_secs(5)).unwrap();
+        });
+        let backend = CartesiaTtsBackend::new(CartesiaConfig {
+            api_key: "test-key".into(),
+            model_id: "test-model".into(),
+            ..Default::default()
+        });
+        assert!(backend.supports_streaming());
+        let stream = backend.synthesize_streaming_from(&url, "hello", "requested-voice").unwrap();
+        assert_eq!(stream.meta.sample_rate, 44100);
+        assert_eq!(stream.meta.channels, 1);
+        assert_eq!(stream.meta.bits_per_sample, 16);
+        let mut pcm = Vec::new();
+        while pcm.len() < 2 {
+            match stream.recv_timeout(Duration::from_secs(5)).unwrap() {
+                Some(ChunkItem::Pcm(bytes)) => pcm.extend(bytes),
+                other => panic!("expected early PCM, got {other:?}"),
+            }
+        }
+        assert_eq!(pcm, vec![1, 2]);
+        release.send(()).unwrap();
+        assert!(matches!(stream.recv_timeout(Duration::from_secs(5)).unwrap(),
+            Some(ChunkItem::Failed(reason)) if reason.contains("after 2 bytes")));
+        assert_eq!(stream.recv_timeout(Duration::from_secs(5)).unwrap(), None);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn streams_complete_body_and_surfaces_api_errors() {
+        for status in [200, 401] {
+            let server = wiremock::MockServer::start().await;
+            wiremock::Mock::given(wiremock::matchers::method("POST"))
+                .respond_with(wiremock::ResponseTemplate::new(status).set_body_bytes(vec![1, 2, 3, 4]))
+                .mount(&server).await;
+            let backend = CartesiaTtsBackend::new(CartesiaConfig {
+                api_key: "test-key".into(),
+                ..Default::default()
+            });
+            let stream = backend.synthesize_streaming_from(&server.uri(), "hello", "voice").unwrap();
+            tokio::task::spawn_blocking(move || {
+                let mut pcm = Vec::new();
+                let mut failed = false;
+                while let Some(item) = stream.recv_timeout(Duration::from_secs(5)).unwrap() {
+                    match item {
+                        ChunkItem::Pcm(bytes) => pcm.extend(bytes),
+                        ChunkItem::Failed(reason) => {
+                            assert!(reason.contains("401"));
+                            failed = true;
+                        }
+                    }
+                }
+                if status == 200 {
+                    assert!(!failed);
+                    assert_eq!(pcm, vec![1, 2, 3, 4]);
+                } else {
+                    assert!(failed);
+                    assert!(pcm.is_empty());
+                }
+            }).await.unwrap();
+        }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "CopySpeak",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "com.copyspeak.tts",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/effects-page.svelte
+++ b/src/lib/components/effects-page.svelte
@@ -67,7 +67,7 @@
   }
 </script>
 
-<div class="mx-auto w-full max-w-2xl px-6 py-8">
+<div class="w-full min-w-0 py-8">
   <header class="mb-6 flex items-center gap-3">
     <Wand2 class="text-primary" size={24} />
     <h1 class="text-2xl font-semibold tracking-tight">{$_("effects.title")}</h1>

--- a/src/lib/components/history-page.svelte
+++ b/src/lib/components/history-page.svelte
@@ -12,6 +12,6 @@
   });
 </script>
 
-<div class="mx-auto w-full min-w-0 max-w-4xl">
+<div class="w-full min-w-0">
   <RecentHistory limit={Infinity} />
 </div>

--- a/src/lib/components/play-page.svelte
+++ b/src/lib/components/play-page.svelte
@@ -2,9 +2,11 @@
   import { onMount, onDestroy } from "svelte";
   import PlaybackControls from "$lib/components/playback-controls.svelte";
   import QuickSettings from "$lib/components/quick-settings.svelte";
+  import RecentHistory from "$lib/components/recent-history.svelte";
   import { Button } from "$lib/components/ui/button/index.js";
   import { Textarea } from "$lib/components/ui/textarea/index.js";
   import { playbackStore } from "$lib/stores/playback-store.svelte";
+  import { historyStore } from "$lib/stores/history-store.svelte";
   import { toast } from "svelte-sonner";
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
@@ -290,6 +292,7 @@
 
   onMount(async () => {
     await loadConfig();
+    if (isTauri && historyStore.items.length === 0) await historyStore.loadHistory();
 
     if (isTauri) {
       try {
@@ -324,10 +327,10 @@
 </script>
 
 <div class="flex min-w-0 flex-1 flex-col gap-4">
-  <div class="grid min-w-0 flex-1 grid-cols-1 gap-6 md:grid-cols-[minmax(0,1fr)_13rem]">
+  <div class="grid min-w-0 flex-1 grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_11.5rem]">
     <section aria-labelledby="reader-heading" class="flex min-w-0 flex-col gap-3">
       <div>
-        <h2 id="reader-heading" class="text-lg font-bold tracking-tight">Read aloud</h2>
+        <h2 id="reader-heading" class="sr-only">Read aloud</h2>
         <p id="reader-hint" class="text-muted-foreground text-sm">
           Paste text here, or copy it twice anywhere.
         </p>
@@ -362,7 +365,7 @@
     {#if config}
       <aside
         aria-label="Reading controls"
-        class="border-border min-w-0 border-t pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-5"
+        class="border-border min-w-0 border-t pt-3 md:border-t-0 md:border-l md:pt-0 md:pl-4"
       >
         <QuickSettings bind:config />
       </aside>
@@ -389,5 +392,9 @@
         })}
       </p>
     </div>
+  {/if}
+
+  {#if config?.history.enabled}
+    <RecentHistory compact limit={5} />
   {/if}
 </div>

--- a/src/lib/components/play-page.svelte
+++ b/src/lib/components/play-page.svelte
@@ -65,7 +65,8 @@
     },
     playback: {
       on_retrigger: "interrupt",
-      volume: 100
+      volume: 100,
+      streaming_enabled: true
     },
     hud: {
       enabled: false,

--- a/src/lib/components/quick-settings.svelte
+++ b/src/lib/components/quick-settings.svelte
@@ -32,14 +32,14 @@
 </script>
 
 <!-- Compact settings panel for quick access to the most-used playback and listening controls -->
-<div class="grid min-w-0 grid-cols-1 gap-x-6 sm:grid-cols-2 md:grid-cols-1">
+<div class="grid min-w-0 grid-cols-1 gap-x-4 sm:grid-cols-2 md:grid-cols-1">
   <!-- Show clipboard listener errors (e.g. permission denied, backend failure) -->
   {#if error}
     <p class="text-destructive text-xs">{error}</p>
   {/if}
   {#if config}
     <!-- Double-copy listener toggle — uses onchange (not bind) because state lives in the store, not config -->
-    <div class="border-border flex min-w-0 items-center justify-between gap-3 border-b py-3">
+    <div class="border-border flex min-w-0 items-center justify-between gap-2 border-b py-2">
       <div class="flex items-center gap-1">
         <Label for="listen-double-copy" class="text-sm">Double-copy</Label>
         <InfoTooltip text="Monitor clipboard for double-copy" />
@@ -47,7 +47,7 @@
       <Switch id="listen-double-copy" checked={isListening} onchange={handleToggle} />
     </div>
     <!-- Global hotkey toggle — binds directly to config since it's a persistent preference -->
-    <div class="border-border flex min-w-0 items-center justify-between gap-3 border-b py-3">
+    <div class="border-border flex min-w-0 items-center justify-between gap-2 border-b py-2">
       <div class="flex items-center gap-1">
         <Label for="qs-hotkey" class="text-sm">Hotkey</Label>
         <InfoTooltip text={config.hotkey.shortcut || "Speak clipboard with a keyboard shortcut"} />
@@ -55,7 +55,7 @@
       <Switch id="qs-hotkey" bind:checked={config.hotkey.enabled} />
     </div>
     <!-- Effects toggle — binds to active profile's effects -->
-    <div class="border-border flex min-w-0 items-center justify-between gap-3 border-b py-3">
+    <div class="border-border flex min-w-0 items-center justify-between gap-2 border-b py-2">
       <div class="flex items-center gap-1">
         <Label for="qs-effects" class="text-sm">Effects</Label>
         <InfoTooltip text="Apply audio effect to TTS playback" />
@@ -75,7 +75,7 @@
       />
     </div>
     <!-- Volume slider — 0–100% range with integer steps for precise control -->
-    <div class="flex min-w-0 flex-col gap-3 py-3">
+    <div class="flex min-w-0 flex-col gap-2 py-2">
       <div class="flex items-center justify-between">
         <Label for="qs-volume" class="text-sm">Volume</Label>
         <span class="text-muted-foreground text-xs">{config.playback.volume}%</span>
@@ -83,7 +83,7 @@
       <Slider id="qs-volume" min={0} max={100} step={1} bind:value={config.playback.volume} />
     </div>
     <!-- Speed slider — reads from active profile -->
-    <div class="flex min-w-0 flex-col gap-3 py-3">
+    <div class="flex min-w-0 flex-col gap-2 py-2">
       <div class="flex items-center justify-between">
         <Label for="qs-speed" class="text-sm">Speed</Label>
         <span class="text-muted-foreground text-xs">{profileSpeed.toFixed(2)}x</span>
@@ -101,7 +101,7 @@
       />
     </div>
     <!-- Pitch slider — reads from active profile -->
-    <div class="flex min-w-0 flex-col gap-3 py-3">
+    <div class="flex min-w-0 flex-col gap-2 py-2">
       <div class="flex items-center justify-between">
         <Label for="qs-pitch" class="text-sm">Pitch</Label>
         <span class="text-muted-foreground text-xs">{profilePitch.toFixed(2)}x</span>

--- a/src/lib/components/recent-history.svelte
+++ b/src/lib/components/recent-history.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { on } from "svelte/events";
   import { Button } from "$lib/components/ui/button/index.js";
   import {
     AlertDialog,
@@ -18,30 +19,48 @@
     DialogHeader,
     DialogTitle
   } from "$lib/components/ui/dialog/index.js";
-  import { Play, Square, Layers, Trash2, Clock } from "@lucide/svelte";
+  import {
+    Play,
+    RotateCcw,
+    Square,
+    Layers,
+    Trash2,
+    Clock,
+    FolderOpen,
+    AudioLines
+  } from "@lucide/svelte";
   import { invoke } from "@tauri-apps/api/core";
+  import { revealItemInDir } from "@tauri-apps/plugin-opener";
   import { Spinner } from "$lib/components/ui/spinner/index.js";
   import { historyStore } from "$lib/stores/history-store.svelte.js";
   import { playbackStore } from "$lib/stores/playback-store.svelte";
-  import { groupHistoryReadings, historyVoiceLabel } from "$lib/models/history";
-  import type { AppConfig, EngineCatalogEntry, VoiceProfile } from "$lib/types";
+  import { groupHistoryReadings, historyVoiceLabel, historyTimeAgo } from "$lib/models/history";
+  import type { AppConfig, EngineCatalogEntry, HistoryItem, VoiceProfile } from "$lib/types";
   import { isTauri } from "$lib/services/tauri";
   import { _ } from "svelte-i18n";
 
   interface Props {
     limit?: number;
+    compact?: boolean;
     onSuccess?: (message: string) => void;
     onError?: (error: string) => void;
   }
 
-  let { limit = 5, onSuccess, onError }: Props = $props();
+  let { limit = 5, compact = false, onSuccess, onError }: Props = $props();
   type Reading = ReturnType<typeof groupHistoryReadings>[number];
+  let now = $state(Date.now());
   let actionInProgress = $state<string | null>(null);
+  let deletingId = $state<string | null>(null);
   let readingToDelete = $state<Reading | null>(null);
   let selectedReading = $state<Reading | null>(null);
   let actionError = $state<string | null>(null);
   let profiles = $state<VoiceProfile[]>([]);
   let engines = $state<EngineCatalogEntry[]>([]);
+
+  onMount(() => {
+    const timer = setInterval(() => (now = Date.now()), 60_000);
+    return () => clearInterval(timer);
+  });
 
   onMount(async () => {
     if (!isTauri) return;
@@ -55,18 +74,42 @@
     else console.error("Failed to load history voice catalog:", catalog.reason);
   });
   const readings = $derived(groupHistoryReadings(historyStore.items).slice(0, limit));
-  const playbackBusy = $derived(playbackStore.isPlaying || playbackStore.isSynthesizing);
+  const playbackBusy = $derived(
+    playbackStore.isPlaying || playbackStore.isLoadingAudio || playbackStore.isSynthesizing
+  );
+
+  function horizontalWheel(node: HTMLUListElement, enabled: boolean) {
+    if (!enabled) return;
+    const cleanup = on(
+      node,
+      "wheel",
+      (event) => {
+        if (
+          event.ctrlKey ||
+          Math.abs(event.deltaX) >= Math.abs(event.deltaY) ||
+          node.scrollWidth <= node.clientWidth
+        )
+          return;
+        event.preventDefault();
+        const unit = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? node.clientWidth : 1;
+        const direction = getComputedStyle(node).direction === "rtl" ? -1 : 1;
+        node.scrollLeft += event.deltaY * unit * direction;
+      },
+      { passive: false }
+    );
+    return { destroy: cleanup };
+  }
 
   async function handlePlay(reading: Reading) {
     actionInProgress = reading.id;
     actionError = null;
     try {
-      if (playbackStore.historyReadingId === reading.id && playbackStore.isPlaying) {
+      if (playbackStore.historyReadingId === reading.id && playbackBusy) {
         playbackStore.handleStop();
         await invoke("stop_speaking");
         return;
       }
-      if (playbackStore.isPlaying) {
+      if (playbackBusy) {
         playbackStore.handleStop();
         await invoke("stop_speaking");
       }
@@ -85,9 +128,10 @@
     const reading = readingToDelete;
     if (!reading) return;
     readingToDelete = null;
-    actionInProgress = reading.id;
+    deletingId = reading.id;
     actionError = null;
     try {
+      if (playbackBusy) throw new Error("Stop playback before deleting a reading.");
       if (reading.batchId) await historyStore.deleteBatch(reading.batchId);
       else await historyStore.deleteItem(reading.items[0].id);
       onSuccess?.("Deleted from history");
@@ -95,7 +139,7 @@
       actionError = `Failed to delete: ${e}`;
       onError?.(actionError);
     } finally {
-      actionInProgress = null;
+      deletingId = null;
     }
   }
 
@@ -103,113 +147,241 @@
     const seconds = Math.round(ms / 1000);
     return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
   }
+
+  function historyFilename(item: HistoryItem) {
+    return item.output_path?.split(/[\\/]/).pop() || "Unsaved reading";
+  }
+
+  async function openHistoryFolder() {
+    const path = readings
+      .flatMap((reading) => reading.items)
+      .find((item) => item.output_path)?.output_path;
+    if (!path) return;
+    try {
+      await revealItemInDir(path);
+    } catch (e) {
+      actionError = `Failed to open history folder: ${e}`;
+      onError?.(actionError);
+    }
+  }
 </script>
 
-<section class="flex min-w-0 flex-col gap-4" aria-labelledby="history-heading">
-  <div class="flex flex-wrap items-baseline justify-between gap-2">
+<section
+  class={compact ? "flex min-w-0 flex-col gap-2" : "flex min-w-0 flex-col gap-4"}
+  aria-labelledby="history-heading"
+>
+  <div class={compact ? "sr-only" : "flex flex-wrap items-baseline justify-between gap-2"}>
     <div>
-      <h2 id="history-heading" class="text-lg font-bold tracking-tight">{$_("history.title")}</h2>
-      <p class="text-muted-foreground text-sm">Your readings, ready to listen again.</p>
+      <h2
+        id="history-heading"
+        class={compact ? "text-base font-bold tracking-tight" : "text-lg font-bold tracking-tight"}
+      >
+        {$_("history.title")}
+      </h2>
+      {#if !compact}
+        <p class="text-muted-foreground text-sm">Your readings, ready to listen again.</p>
+      {/if}
     </div>
-    {#if historyStore.isLoading}
-      <span class="text-muted-foreground text-xs" role="status">{$_("history.loading")}</span>
-    {/if}
+    <div class="flex items-center gap-2">
+      {#if historyStore.isLoading}
+        <span class="text-muted-foreground text-xs" role="status">{$_("history.loading")}</span>
+      {/if}
+    </div>
   </div>
 
   {#if readings.length === 0 && !historyStore.isLoading}
-    <div class="text-muted-foreground flex flex-col items-center gap-3 py-12">
+    <div
+      class={compact
+        ? "text-muted-foreground flex flex-col items-center gap-2 py-6"
+        : "text-muted-foreground flex flex-col items-center gap-3 py-12"}
+    >
       <Clock class="size-6" />
       <p class="text-sm">{$_("history.empty")}</p>
     </div>
   {:else}
-    <ul class="border-border divide-border divide-y border-y">
+    <ul
+      use:horizontalWheel={compact}
+      class={compact
+        ? "recent-history-rail flex min-w-0 gap-4 overflow-x-auto overscroll-x-contain pb-2"
+        : "border-border divide-border divide-y border-y"}
+    >
       {#each readings as reading (reading.id)}
         {@const item = reading.items[0]}
         {@const isCurrent = playbackStore.historyReadingId === reading.id}
-        {@const isActive = isCurrent && playbackStore.isPlaying}
+        {@const isActive = isCurrent && (playbackStore.isPlaying || playbackStore.isLoadingAudio)}
         {@const actionLabel = isActive
           ? $_("play.stop")
           : isCurrent
             ? $_("play.replay")
             : $_("play.play")}
-        <li class="hover:bg-muted/40 flex min-w-0 items-start gap-3 px-2 py-4 transition-colors sm:px-3">
-          <Button
-            variant={isActive ? "secondary" : "outline"}
-            size="icon"
-            class="shrink-0"
-            onclick={() => handlePlay(reading)}
-            disabled={actionInProgress !== null || playbackStore.isSynthesizing || !reading.hasAudio}
-            aria-label={actionLabel}
-            title={isActive
-              ? actionLabel
-              : !reading.hasAudio
-                ? $_("history.noAudioFile")
-                : actionLabel}
-          >
-            {#if actionInProgress === reading.id}
-              <Spinner />
-            {:else if isActive}
-              <Square />
-            {:else}
-              <Play />
-            {/if}
-          </Button>
-          <div class="flex min-w-0 flex-1 flex-col gap-2">
+        <li
+          class={compact
+            ? "flex w-80 shrink-0 flex-col gap-1 py-1 pr-2"
+            : "hover:bg-muted/40 flex min-w-0 flex-col gap-2 px-2 py-3 transition-colors sm:px-3"}
+        >
+          {#if !compact}
+            <div class="flex min-w-0 items-center gap-2">
+              <span
+                class="min-w-0 flex-1 truncate text-sm font-bold"
+                title={item.output_path || historyFilename(item)}
+              >
+                {historyFilename(item)}
+              </span>
+              <Button
+                variant={isActive ? "secondary" : "ghost"}
+                size="sm"
+                class="shrink-0 gap-1.5"
+                onclick={() => handlePlay(reading)}
+                disabled={actionInProgress !== null ||
+                  deletingId !== null ||
+                  playbackStore.isSynthesizing ||
+                  !reading.hasAudio}
+                aria-label={actionLabel}
+                title={isActive
+                  ? actionLabel
+                  : !reading.hasAudio
+                    ? $_("history.noAudioFile")
+                    : actionLabel}
+              >
+                {#if actionInProgress === reading.id || (isCurrent && playbackStore.isLoadingAudio)}
+                  <Spinner aria-hidden="true" />
+                {:else if isActive}
+                  <Square />
+                {:else if isCurrent}
+                  <RotateCcw />
+                {:else}
+                  <Play />
+                {/if}
+                <span>{actionLabel}</span>
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                class="text-muted-foreground hover:text-destructive shrink-0"
+                onclick={() => (readingToDelete = reading)}
+                disabled={actionInProgress !== null || deletingId !== null || playbackBusy}
+                aria-label={$_("history.delete")}
+                title={$_("history.delete")}
+              >
+                {#if deletingId === reading.id}
+                  <Spinner aria-hidden="true" />
+                {:else}
+                  <Trash2 />
+                {/if}
+              </Button>
+            </div>
+          {/if}
+          <div class={compact ? "min-w-0" : "flex min-w-0 flex-1 flex-col gap-1.5"}>
             <button
               type="button"
-              class="focus-visible:ring-ring min-w-0 cursor-pointer rounded-sm text-left text-sm leading-relaxed focus-visible:ring-2 focus-visible:outline-none"
+              class={compact
+                ? "focus-visible:ring-ring text-muted-foreground block w-full cursor-pointer overflow-hidden rounded-sm text-left text-sm leading-snug focus-visible:ring-2 focus-visible:outline-none"
+                : "focus-visible:ring-ring min-w-0 cursor-pointer rounded-sm text-left text-sm leading-relaxed focus-visible:ring-2 focus-visible:outline-none"}
               onclick={() => (selectedReading = reading)}
               aria-label="Read full text"
               aria-haspopup="dialog"
               title="Read full text"
             >
-              <span class="line-clamp-2 min-h-10 whitespace-pre-wrap wrap-anywhere"
-                >{reading.text}</span
+              <span
+                class={compact
+                  ? "line-clamp-3 whitespace-pre-wrap wrap-anywhere"
+                  : "line-clamp-2 min-h-10 whitespace-pre-wrap wrap-anywhere"}>{reading.text}</span
               >
             </button>
-            <div class="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-              <time datetime={new Date(reading.timestamp).toISOString()}>
-                {new Date(reading.timestamp).toLocaleString(undefined, {
-                  dateStyle: "medium",
-                  timeStyle: "short"
-                })}
-              </time>
-              <span class="max-w-full truncate" title={`${item.tts_engine} · ${item.voice}`}
-                >{engines.find((engine) => engine.engine === item.tts_engine)?.label ??
-                  item.tts_engine} · {historyVoiceLabel(item, profiles, engines)}</span
+            {#if !compact}
+              <div
+                class="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs"
               >
-              {#if reading.durationMs > 0}
-                <span class="tabular-nums">{formatDuration(reading.durationMs)}</span>
-              {/if}
-              {#if reading.partCount > 1}
-                <span
-                  class="inline-flex items-center gap-1 whitespace-nowrap"
-                  title="Paginated reading; plays all saved parts in order"
+                <time
+                  datetime={new Date(reading.timestamp).toISOString()}
+                  title={new Date(reading.timestamp).toLocaleString()}
                 >
-                  <Layers class="size-3" />
-                  {reading.partCount} parts
-                </span>
-              {/if}
-              {#if !reading.success}
-                <span class="text-destructive">Generation failed</span>
-              {:else if !reading.hasAudio}
-                <span>{$_("history.noAudioFile")}</span>
-              {/if}
-            </div>
+                  {historyTimeAgo(reading.timestamp, now)}
+                </time>
+                <span class="max-w-full truncate" title={`${item.tts_engine} · ${item.voice}`}
+                  >{engines.find((engine) => engine.engine === item.tts_engine)?.label ??
+                    item.tts_engine} · {historyVoiceLabel(item, profiles, engines)}</span
+                >
+                {#if reading.durationMs > 0}
+                  <span class="tabular-nums">{formatDuration(reading.durationMs)}</span>
+                {/if}
+                {#if reading.partCount > 1}
+                  <span
+                    class="inline-flex items-center gap-1 whitespace-nowrap"
+                    title="Paginated reading; plays all saved parts in order"
+                  >
+                    <Layers class="size-3" />
+                    {reading.partCount} parts
+                  </span>
+                {/if}
+                {#if !reading.success}
+                  <span class="text-destructive">Generation failed</span>
+                {:else if !reading.hasAudio}
+                  <span>{$_("history.noAudioFile")}</span>
+                {/if}
+              </div>
+            {/if}
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            class="shrink-0"
-            onclick={() => (readingToDelete = reading)}
-            disabled={actionInProgress !== null || playbackBusy}
-            aria-label={$_("history.delete")}
-            title={$_("history.delete")}
-          >
-            <Trash2 />
-          </Button>
+          {#if compact}
+            <div class="order-first flex min-w-0 items-center gap-2">
+              <span
+                class="border-2 text-muted-foreground flex size-6 shrink-0 items-center justify-center rounded-full"
+                aria-hidden="true"
+              >
+                <AudioLines class="size-3.5" strokeWidth={4} />
+              </span>
+              <span
+                class="min-w-0 flex-1 truncate text-sm font-normal"
+                title={item.output_path || historyFilename(item)}
+              >
+                {historyFilename(item)}
+              </span>
+              <Button
+                variant={isActive ? "secondary" : "ghost"}
+                size="icon-sm"
+                class="shrink-0"
+                onclick={() => handlePlay(reading)}
+                disabled={actionInProgress !== null ||
+                  deletingId !== null ||
+                  playbackStore.isSynthesizing ||
+                  !reading.hasAudio}
+                aria-label={actionLabel}
+                title={isActive
+                  ? actionLabel
+                  : !reading.hasAudio
+                    ? $_("history.noAudioFile")
+                    : actionLabel}
+              >
+                {#if actionInProgress === reading.id || (isCurrent && playbackStore.isLoadingAudio)}
+                  <Spinner aria-hidden="true" />
+                {:else if isActive}
+                  <Square />
+                {:else if isCurrent}
+                  <RotateCcw />
+                {:else}
+                  <Play />
+                {/if}
+              </Button>
+            </div>
+          {/if}
         </li>
       {/each}
+      {#if compact}
+        <li class="flex w-40 shrink-0 flex-col justify-center gap-2">
+          <Button href="/history" variant="ghost" class="w-full text-muted-foreground">
+            View more
+          </Button>
+          <Button
+            variant="ghost"
+            class="w-full text-muted-foreground"
+            onclick={openHistoryFolder}
+            disabled={!readings.some((reading) => reading.items.some((item) => item.output_path))}
+          >
+            <FolderOpen />
+            Open folder
+          </Button>
+        </li>
+      {/if}
     </ul>
   {/if}
 
@@ -258,3 +430,36 @@
     </AlertDialogFooter>
   </AlertDialogContent>
 </AlertDialog>
+
+<style>
+  /* Hallmark · pre-emit critique: P5 H5 E4 S5 R5 V4
+   * component: history rail · genre: modern-minimal · theme: CopySpeak teal
+   * contrast: pass (40–41) · tokens: pass (48) · responsive: pass (49)
+   */
+  .recent-history-rail {
+    transform: rotateX(180deg);
+    scrollbar-color: color-mix(in oklch, var(--muted-foreground) 35%, transparent) transparent;
+    scrollbar-width: thin;
+  }
+
+  .recent-history-rail > li {
+    transform: rotateX(180deg);
+  }
+
+  .recent-history-rail::-webkit-scrollbar {
+    height: 5px;
+  }
+
+  .recent-history-rail::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .recent-history-rail::-webkit-scrollbar-thumb {
+    background: color-mix(in oklch, var(--muted-foreground) 35%, transparent);
+    border-radius: var(--radius);
+  }
+
+  .recent-history-rail::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  }
+</style>

--- a/src/lib/components/recent-history.test.ts
+++ b/src/lib/components/recent-history.test.ts
@@ -1,0 +1,51 @@
+import { expect, it, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import { waitForI18nReady } from "$lib/i18n";
+import RecentHistory from "./recent-history.svelte";
+
+vi.mock("$lib/services/tauri", () => ({ isTauri: false }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ revealItemInDir: vi.fn() }));
+vi.mock("$lib/stores/history-store.svelte.js", () => ({
+  historyStore: {
+    items: Array.from({ length: 6 }, (_, index) => ({
+      id: String(index), timestamp: Date.now() - index * 60_000,
+      text: `Reading ${index}`, tts_engine: "cartesia", voice: "saved",
+      success: true, output_path: `/audio/${index}.wav`
+    }))
+  }
+}));
+
+it("scrolls the five-reading preview sideways with the wheel and ends with History navigation", async () => {
+  await waitForI18nReady();
+  const view = render(RecentHistory, { compact: true, limit: 5 });
+  const rail = view.getByRole("list");
+  Object.defineProperties(rail, {
+    scrollWidth: { value: 1600 }, clientWidth: { value: 600 }
+  });
+  const wheel = new WheelEvent("wheel", { deltaY: 100, cancelable: true });
+  rail.dispatchEvent(wheel);
+  expect(rail.scrollLeft).toBe(100);
+  expect(wheel.defaultPrevented).toBe(true);
+  const zoom = new WheelEvent("wheel", { deltaY: 100, ctrlKey: true, cancelable: true });
+  rail.dispatchEvent(zoom);
+  expect(rail.scrollLeft).toBe(100);
+  expect(zoom.defaultPrevented).toBe(false);
+  rail.style.direction = "rtl";
+  rail.scrollLeft = 0;
+  rail.dispatchEvent(new WheelEvent("wheel", { deltaY: 40, cancelable: true }));
+  expect(rail.scrollLeft).toBe(-40);
+  expect(view.getAllByRole("listitem")).toHaveLength(6);
+  expect(view.queryByRole("button", { name: "Delete" })).toBeNull();
+  const link = view.getByRole("link", { name: "View more" });
+  expect(link.getAttribute("href")).toBe("/history");
+  expect(view.getByRole("button", { name: "Open folder" })).toBeTruthy();
+  expect(rail.lastElementChild?.contains(link)).toBe(true);
+  view.unmount();
+
+  const history = render(RecentHistory, { limit: Infinity });
+  const verticalWheel = new WheelEvent("wheel", { deltaY: 100, cancelable: true });
+  history.getByRole("list").dispatchEvent(verticalWheel);
+  expect(verticalWheel.defaultPrevented).toBe(false);
+  expect(history.queryByRole("link", { name: "View more →" })).toBeNull();
+  history.unmount();
+});

--- a/src/lib/components/settings-page.svelte
+++ b/src/lib/components/settings-page.svelte
@@ -204,7 +204,7 @@
   });
 </script>
 
-<div class="w-full">
+<div class="w-full min-w-0">
   {#if isLoading}
     <div class="flex min-h-[60vh] items-center justify-center">
       <div class="text-center">

--- a/src/lib/components/settings/playback-settings.svelte
+++ b/src/lib/components/settings/playback-settings.svelte
@@ -2,6 +2,7 @@
   import { SettingRow } from "$lib/components/ui/setting-row/index.js";
   import { Select } from "$lib/components/ui/select/index.js";
   import { Slider } from "$lib/components/ui/slider/index.js";
+  import { Switch } from "$lib/components/ui/switch/index.js";
   import type { AppConfig } from "$lib/types";
   import { _ } from "svelte-i18n";
 
@@ -15,6 +16,20 @@
 </script>
 
 <div class="space-y-4">
+  <div>
+    <SettingRow label={$_("settings.playback.streaming")}>
+      <Switch
+        id="playback-streaming"
+        aria-label={$_("settings.playback.streaming")}
+        aria-describedby="playback-streaming-description"
+        bind:checked={localConfig.playback.streaming_enabled}
+      />
+    </SettingRow>
+    <p id="playback-streaming-description" class="text-muted-foreground text-sm">
+      {$_("settings.playback.streamingDescription")}
+    </p>
+  </div>
+
   <SettingRow
     label={$_("settings.playback.onRetrigger")}
     tooltip={$_("settings.playback.onRetriggerDescription")}

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -100,6 +100,8 @@ export type TranslationKeys =
   | "settings.playback.onRetriggerDescription"
   | "settings.playback.volume"
   | "settings.playback.volumeDescription"
+  | "settings.playback.streaming"
+  | "settings.playback.streamingDescription"
   | "settings.playback.playbackSpeed"
   | "settings.playback.playbackSpeedDescription"
   | "settings.playback.pitch"

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -103,6 +103,8 @@
       "onRetriggerDescription": "What happens when TTS is triggered while already speaking",
       "volume": "Volume",
       "volumeDescription": "Audio playback volume (0-100%)",
+      "streaming": "Stream audio",
+      "streamingDescription": "Start playback as audio arrives. Supported cloud engines: ElevenLabs and Cartesia. When disabled, use batch synthesis and wait for each request to finish before playback.",
       "playbackSpeed": "Speed",
       "playbackSpeedDescription": "Playback speed (0.5x - 2x)",
       "pitch": "Pitch",

--- a/src/lib/models/history.test.ts
+++ b/src/lib/models/history.test.ts
@@ -1,6 +1,16 @@
 import { expect, it } from "vitest";
-import { createHistoryItem, groupHistoryReadings, historyVoiceLabel } from "./history";
+import { createHistoryItem, groupHistoryReadings, historyVoiceLabel, historyTimeAgo } from "./history";
 import type { EngineCatalogEntry, VoiceProfile } from "$lib/types";
+
+it("shows elapsed time at minute, hour, and day boundaries", () => {
+  const now = 200_000_000;
+  const formatter = new Intl.RelativeTimeFormat(undefined, { style: "short" });
+  expect(historyTimeAgo(now + 60_000, now)).toBe("Just now");
+  expect(historyTimeAgo(now - 59_999, now)).toBe("Just now");
+  expect(historyTimeAgo(now - 60_000, now)).toBe(formatter.format(-1, "minute"));
+  expect(historyTimeAgo(now - 3_600_000, now)).toBe(formatter.format(-1, "hour"));
+  expect(historyTimeAgo(now - 86_400_000, now)).toBe(formatter.format(-1, "day"));
+});
 
 it("uses matching voice labels without confusing engine IDs or exposing unknown IDs", () => {
   const item = createHistoryItem("Hello", "cartesia", "voice-id", 1);

--- a/src/lib/models/history.ts
+++ b/src/lib/models/history.ts
@@ -133,6 +133,15 @@ export function formatHistoryDate(timestamp: number): string {
   return date.toLocaleString();
 }
 
+export function historyTimeAgo(timestamp: number, now: number): string {
+  const minutes = Math.max(0, Math.floor((now - timestamp) / 60_000));
+  if (minutes === 0) return "Just now";
+  const formatter = new Intl.RelativeTimeFormat(undefined, { style: "short" });
+  if (minutes < 60) return formatter.format(-minutes, "minute");
+  if (minutes < 1440) return formatter.format(-Math.floor(minutes / 60), "hour");
+  return formatter.format(-Math.floor(minutes / 1440), "day");
+}
+
 /**
  * Formats a timestamp to ISO date string (YYYY-MM-DD)
  */

--- a/src/lib/stores/playback-store.svelte.ts
+++ b/src/lib/stores/playback-store.svelte.ts
@@ -22,6 +22,7 @@ class PlaybackStore {
   isPlaying = $state(false);
   isPaused = $state(false);
   isSynthesizing = $state(false);
+  isLoadingAudio = $state(false);
   error = $state<string | null>(null);
   hasCachedAudio = $state(false);
   // Retained after stop/completion so the owning history row can offer Replay.
@@ -47,6 +48,7 @@ class PlaybackStore {
   private _emitTo: ((target: string, name: string, payload: unknown) => Promise<void>) | null =
     null;
   private _stopping = false;
+  private _playbackGeneration = 0;
 
   // Modular components
   private _analyser = new AudioAnalyser();
@@ -93,6 +95,7 @@ class PlaybackStore {
   }
 
   async buildPlaybackUrl(pitchRatio: number): Promise<string> {
+    const generation = this._playbackGeneration;
     const effectId = this.activeEffect;
     if (
       this._cachedPitchUrl &&
@@ -144,44 +147,52 @@ class PlaybackStore {
     } else {
       return "";
     }
+    if (generation !== this._playbackGeneration) return "";
     const url = URL.createObjectURL(blob);
     this._cachedPitchUrl = { ratio: pitchRatio, effectId, url };
     return url;
   }
 
   async handleAudioReady(base64: string): Promise<void> {
-    console.log("[PlaybackStore] handleAudioReady called, base64 length:", base64.length);
-    const binary = atob(base64);
-    const arrayBuffer = new ArrayBuffer(binary.length);
-    const bytes = new Uint8Array(arrayBuffer);
-    for (let i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i);
-    }
-
-    this._originalBytes = arrayBuffer.slice(0);
-    if (this._cachedPitchUrl) {
-      URL.revokeObjectURL(this._cachedPitchUrl.url);
-      this._cachedPitchUrl = null;
-    }
-
-    if (!this._audioCtx) {
-      this._audioCtx = new AudioContext();
-    }
-
-    // Resume AudioContext if suspended (required on clean Windows 11 / strict autoplay policies)
-    if (this._audioCtx.state === "suspended") {
-      await this._audioCtx.resume();
-    }
-
-    // Wire AnalyserNode once per audio element (guard prevents double-wiring)
-    if (this._audioEl && this._audioCtx && !this._analyser.getAnalyser()) {
-      this._analyser.setup(this._audioEl, this._audioCtx, {
-        emitTo: this._emitTo
-      });
-    }
-
+    const generation = this._playbackGeneration;
+    this.isLoadingAudio = true;
+    this.error = null;
+    this.hasCachedAudio = false;
     try {
-      this._decodedBuffer = await this._audioCtx.decodeAudioData(arrayBuffer.slice(0));
+      console.log("[PlaybackStore] handleAudioReady called, base64 length:", base64.length);
+      const binary = atob(base64);
+      const arrayBuffer = new ArrayBuffer(binary.length);
+      const bytes = new Uint8Array(arrayBuffer);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+
+      this._originalBytes = arrayBuffer.slice(0);
+      if (this._cachedPitchUrl) {
+        URL.revokeObjectURL(this._cachedPitchUrl.url);
+        this._cachedPitchUrl = null;
+      }
+
+      if (!this._audioCtx) {
+        this._audioCtx = new AudioContext();
+      }
+
+      // Resume AudioContext if suspended (required on clean Windows 11 / strict autoplay policies)
+      if (this._audioCtx.state === "suspended") {
+        await this._audioCtx.resume();
+      }
+      if (generation !== this._playbackGeneration) return;
+
+      // Wire AnalyserNode once per audio element (guard prevents double-wiring)
+      if (this._audioEl && !this._analyser.getAnalyser()) {
+        this._analyser.setup(this._audioEl, this._audioCtx, {
+          emitTo: this._emitTo
+        });
+      }
+
+      const decoded = await this._audioCtx.decodeAudioData(arrayBuffer.slice(0));
+      if (generation !== this._playbackGeneration) return;
+      this._decodedBuffer = decoded;
       if (this._decodedBuffer) {
         const accurateDurationMs = Math.round(this._decodedBuffer.duration * 1000);
         hudStore.setAccurateDurationMs(accurateDurationMs);
@@ -189,14 +200,19 @@ class PlaybackStore {
         this._emit?.("hud:audio-duration", accurateDurationMs);
       }
       const url = await this.buildPlaybackUrl(this.pitch);
-      if (this._audioEl && url) {
-        this._audioEl.src = url;
-        this._analyser.start(); // Start amplitude capture BEFORE audio plays
-        this.playAudio();
-      }
+      if (generation !== this._playbackGeneration) return;
+      if (!this._audioEl || !url) throw new Error("Audio player is not ready");
+      this._audioEl.src = url;
+      this._analyser.start(); // Start amplitude capture BEFORE audio plays
+      await this.playAudio();
+      if (generation !== this._playbackGeneration) return;
       this.hasCachedAudio = true;
     } catch (e) {
-      this.error = `Audio decode error: ${e}`;
+      if (generation !== this._playbackGeneration) return;
+      this.handleStop();
+      this.error = `Audio playback failed: ${e}`;
+    } finally {
+      if (generation === this._playbackGeneration) this.isLoadingAudio = false;
     }
   }
 
@@ -285,10 +301,9 @@ class PlaybackStore {
     this._pcmScheduler.handleChunk(payload);
   }
 
-  playAudio() {
+  async playAudio() {
     if (!this._audioEl) {
-      console.error("[PlaybackStore] playAudio: no audio element");
-      return;
+      throw new Error("Audio player is not ready");
     }
     this._audioEl.volume = this.volume / 100;
     this._audioEl.playbackRate = this.speed;
@@ -300,9 +315,7 @@ class PlaybackStore {
       "src",
       this._audioEl.src?.substring(0, 50)
     );
-    this._audioEl.play().catch((err) => {
-      console.error("[PlaybackStore] play() failed:", err);
-    });
+    await this._audioEl.play();
   }
 
   async handleReplay(): Promise<void> {
@@ -312,11 +325,18 @@ class PlaybackStore {
     if (url) {
       this._audioEl.src = url;
       this._audioEl.currentTime = 0;
-      this.playAudio();
+      try {
+        await this.playAudio();
+      } catch (e) {
+        this.handleStop();
+        this.error = `Audio playback failed: ${e}`;
+      }
     }
   }
 
   handleStop() {
+    this._playbackGeneration += 1;
+    this.isLoadingAudio = false;
     this._analyser.stop();
     this._stopping = true;
 
@@ -476,6 +496,7 @@ class PlaybackStore {
   }
 
   teardownListeners() {
+    this.handleStop();
     this._analyser.stop();
     this._analyser.destroy();
     this._pcmScheduler?.stop();

--- a/src/lib/stores/playback-store.test.ts
+++ b/src/lib/stores/playback-store.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { playbackStore } from "./playback-store.svelte";
+
+const { listeners } = vi.hoisted(() => ({
+  listeners: new Map<string, (event: { payload: unknown }) => Promise<void>>()
+}));
+vi.mock("$lib/services/tauri.js", () => ({ isTauri: true }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (name, callback) => {
+    listeners.set(name, callback);
+    return () => listeners.delete(name);
+  }),
+  emit: vi.fn(async () => {}),
+  emitTo: vi.fn(async () => {})
+}));
+vi.mock("./playback/analyser.js", () => ({
+  AudioAnalyser: class {
+    getAnalyser() { return null; }
+    setup() {}
+    start() {}
+    stop() {}
+    destroy() {}
+  }
+}));
+
+const decode = vi.fn(async () => ({ duration: 1 }));
+let audio: HTMLAudioElement;
+
+beforeEach(async () => {
+  decode.mockReset().mockResolvedValue({ duration: 1 });
+  vi.stubGlobal("AudioContext", class {
+    state = "running";
+    decodeAudioData = decode;
+    close = vi.fn();
+  });
+  audio = document.createElement("audio");
+  vi.spyOn(audio, "pause").mockImplementation(() => {});
+  vi.spyOn(audio, "play").mockImplementation(async () => {
+    audio.dispatchEvent(new Event("play"));
+  });
+  vi.spyOn(playbackStore, "buildPlaybackUrl").mockResolvedValue("blob:history-audio");
+  playbackStore.setAudioElement(audio);
+  playbackStore.historyReadingId = "batch:reading";
+  await playbackStore.setupListeners();
+});
+
+afterEach(() => {
+  playbackStore.teardownListeners();
+  playbackStore.setAudioElement(null);
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function sendAudio(index?: number) {
+  const name = index === undefined ? "audio-ready" : "audio-fragment-ready";
+  await listeners.get(name)!({
+    payload: index === undefined ? "YQ==" : {
+      audio_base64: "YQ==", fragment_index: index, fragment_total: 2,
+      is_final: index === 1, text: `Part ${index}`
+    }
+  });
+}
+
+it.each(["decode", "play"])("releases the queue after a %s failure so history can retry", async (failure) => {
+  if (failure === "decode") decode.mockRejectedValueOnce(new Error("broken audio"));
+  else vi.mocked(audio.play).mockRejectedValueOnce(new Error("play rejected"));
+  await sendAudio();
+  expect(playbackStore.error).toContain("Audio playback failed");
+  expect(playbackStore.isLoadingAudio).toBe(false);
+  expect(playbackStore.isPlaying).toBe(false);
+  await sendAudio();
+  expect(decode).toHaveBeenCalledTimes(2);
+  expect(playbackStore.isPlaying).toBe(true);
+  expect(playbackStore.error).toBeNull();
+});
+
+it("does not restart a stopped reading when its pending decode finishes", async () => {
+  const pending = Promise.withResolvers<{ duration: number }>();
+  decode.mockReturnValueOnce(pending.promise);
+  const first = sendAudio(0);
+  expect(playbackStore.isLoadingAudio).toBe(true);
+  playbackStore.handleStop();
+  pending.resolve({ duration: 1 });
+  await first;
+  expect(audio.play).not.toHaveBeenCalled();
+  expect(playbackStore.isLoadingAudio).toBe(false);
+  await sendAudio(0);
+  expect(audio.play).toHaveBeenCalledTimes(1);
+});
+
+it("plays grouped fragments in order and retains the reading for Replay", async () => {
+  await sendAudio(0);
+  await sendAudio(1);
+  expect(audio.play).toHaveBeenCalledTimes(1);
+  expect(playbackStore.currentFragmentIndex).toBe(0);
+  audio.dispatchEvent(new Event("ended"));
+  await vi.waitFor(() => expect(audio.play).toHaveBeenCalledTimes(2));
+  expect(playbackStore.currentFragmentIndex).toBe(1);
+  audio.dispatchEvent(new Event("ended"));
+  expect(playbackStore.isPlaying).toBe(false);
+  expect(playbackStore.historyReadingId).toBe("batch:reading");
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -250,6 +250,7 @@ export interface PostProcessingConfig {
 export interface PlaybackConfig {
   on_retrigger: RetriggerMode;
   volume: number;
+  streaming_enabled: boolean;
 }
 
 export type HudThemePreset = "dark" | "light" | "custom";

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -230,7 +230,11 @@
           ? "min-h-0 min-w-0 overflow-auto"
           : "min-h-0 min-w-0 overflow-auto px-4 py-4 sm:px-6"}
       >
-        <MotionWrapper class="min-h-full min-w-0 flex flex-col">
+        <MotionWrapper
+          class={isOnboarding
+            ? "min-h-full min-w-0 flex flex-col"
+            : "mx-auto flex min-h-full w-full min-w-0 max-w-6xl flex-col"}
+        >
           {@render children()}
         </MotionWrapper>
       </main>

--- a/src/routes/engines/+page.svelte
+++ b/src/routes/engines/+page.svelte
@@ -79,7 +79,7 @@
       </div>
     </div>
   {:else if localConfig}
-    <main class="mx-auto max-w-3xl pb-4">
+    <main class="w-full min-w-0 pb-4">
       <div class="mb-4">
         <h1 class="text-xl font-semibold">{$_("engines.title")}</h1>
         <p class="text-muted-foreground mt-1 text-sm">{$_("engines.subtitle")}</p>

--- a/src/routes/voices/+page.svelte
+++ b/src/routes/voices/+page.svelte
@@ -92,7 +92,7 @@
       </div>
     </div>
   {:else if localConfig}
-    <main class="mx-auto max-w-3xl pb-20">
+    <main class="w-full min-w-0 pb-20">
       <ProfileManager bind:localConfig />
     </main>
   {:else}


### PR DESCRIPTION
## Summary
- Compact recent-history rail on the Play page (5 most recent readings, wheel-scrollable, link to full History)
- Relative time labels, per-reading part counts, and History-only Delete action
- Fixed audio queue recovery: clear queue on decode/play failure, invalidate pending decoding on Stop
- Bump to 0.1.15 (package.json, tauri.conf.json, Cargo.toml, Cargo.lock) + changelog

## Checks
- `bun run check`: 0 errors, 0 warnings
- `bun run test`: 38/38 passed