### PR TITLE
feat(playback): independent speed and pitch via SoundTouch time-stretch (v0.1.17)

### DIFF
--- a/.pi/extensions/copyspeak/index.ts
+++ b/.pi/extensions/copyspeak/index.ts
@@ -47,8 +47,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("agent_start", async (_event, ctx) => {
     spokenThinkingBlocks = new Set();
-    if (state.enabled && state.speakActivity)
-      await speakSafe("CopySpeak: agent thinking.", ctx);
+    if (state.enabled && state.speakActivity) await speakSafe("CopySpeak: agent thinking.", ctx);
   });
 
   pi.on("message_update", async (event, ctx) => {
@@ -97,7 +96,7 @@ export default function (pi: ExtensionAPI) {
         else if (cmd === "test")
           await speakSafe(
             args.replace(/^test\s*/, "") ||
-            "CopySpeak voice hook is online with walkie talkie effect.",
+              "CopySpeak voice hook is online with walkie talkie effect.",
             ctx,
             true
           );

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
-  "i18n-ally.localesPaths": [
-    "src/lib/i18n",
-    "src/lib/locales"
-  ],
-  "i18n-ally.keystyle": "nested",
+  "i18n-ally.localesPaths": ["src/lib/i18n", "src/lib/locales"],
+  "i18n-ally.keystyle": "nested"
   // "rust-analyzer.linkedProjects": [
   //   "src-tauri/Cargo.toml"
   // ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,8 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 
 - Check credential presence without printing `.env` values; never grep secret files into command output.
 - Preserve native caption intervals with their generated audio through stream framing, cache/history replay, and sample-count-based fragment concatenation; never scale word timings by text weights.
-- Reschedule unstarted PCM sources when playback speed or pitch changes; setting playbackRate does not move their scheduled start times.
-
+- Route playback speed and pitch through `TimeStretcher` (SoundTouch `pitch` setter, then `stretch.tempo = speed / pitch`); keep `playbackRate` at 1 on PCM sources and track `ScheduledPosition` duration/offset/rate in native time.
+- On a rate change, re-stretch the native chunks of unstarted PCM sources; audio already rendered keeps the rate it was rendered at, since absolute start times do not move.
 - Drive HUD captions from the audible fragment's audio clock; synthesis events may describe a later fragment, and incoming PCM chunks must not resume a user-paused stream.
 - Update `play-page.svelte`'s browser mock config when adding required `AppConfig` fields, matching backend defaults.
 - Treat `git diff --check` as a check; do not run it before explicit confirmation.
@@ -60,6 +60,7 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 - Pass `uv init` its target directory positionally (`uv init --bare --name X <dir>`); uv 0.12+ hard-errors on `uv --project <dir> init`, which only shows up when creating a fresh engine project.
 
 <!-- rtk-instructions v2 -->
+
 ## RTK (Rust Token Killer) - Token-Optimized Commands
 
 ## Golden Rule
@@ -75,5 +76,6 @@ git add . && git commit -m "msg" && git push
 # ✅ Correct
 rtk git add . && rtk git commit -m "msg" && rtk git push
 ```
+
 Full command reference (which tools have dedicated filters, and their savings): the `rtk-commands` skill in `.agents/skills/rtk-commands/`.
 <!-- /rtk-instructions -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.17] - 2026-09-08
+
+### Changed
+
+- **Speed and pitch are now independent knobs** — speed time-stretches the audio while preserving pitch (no more chipmunk voice when speeding up) and pitch shifts the voice without changing how long the reading takes. Previously both were a single resampling factor, so each knob moved the other. Both playback paths route through SoundTouch's WSOLA stretcher (`playback/time-stretch.ts`): the streaming PCM scheduler stretches each chunk before scheduling it and keeps `playbackRate` at 1, while the `<audio>` path bakes the pitch shift into the rendered blob at native duration and leaves speed to `preservesPitch` + `playbackRate`.
+- **Speed and pitch ranges tightened** — speed caps at 0.5-2.0 (the IPC clamp was 0.25-4.0, inconsistent with every slider) and pitch narrows from 0.5-2.0 to 0.75-1.35, roughly ±5 semitones. A full octave was only tolerable while pitch also changed speed. Existing profiles keep their values, clamped into range on load; because pitch no longer secretly adds speed, a saved profile may read slower than it used to.
+
+### Removed
+
+- Dead WAV concatenation helpers (`concat_wav_files`, `find_wav_data_offset`) left over from the pre-streaming batch path.
 
 ## [0.1.16] - 2026-09-08
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CopySpeak
 
-**Current Version:** 0.1.16
+**Current Version:** 0.1.17
 
 A modern Windows desktop app that reads clipboard text aloud using AI Text-to-Speech engines. Trigger speech by quickly copying the same text twice in a row.
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -11,20 +11,20 @@ pitch + effect as one swappable unit.
 
 ## Engine matrix
 
-| Engine             | Type   | API key        | Offline | Installer                | Setup test               |
-| ------------------ | ------ | -------------- | ------- | ------------------------ | ------------------------ |
+| Engine             | Type   | API key        | Offline | Installer                      | Setup test               |
+| ------------------ | ------ | -------------- | ------- | ------------------------------ | ------------------------ |
 | Edge-TTS           | cloud  | no             | no      | — (`uv tool install edge-tts`) | `test_tts_engine_config` |
-| Cartesia (Sonic)   | cloud  | yes            | no      | —                        | `test_tts_engine_config` |
-| ElevenLabs         | cloud  | yes            | no      | —                        | `test_tts_engine_config` |
-| OpenAI             | cloud  | yes            | no      | —                        | `test_tts_engine_config` |
-| Google Gemini TTS  | cloud  | yes            | no      | —                        | `test_tts_engine_config` |
-| Microsoft / Azure  | cloud  | yes + endpoint | no      | —                        | `test_tts_engine_config` |
-| Kitten TTS         | local  | no             | yes     | `install-kittentts.ps1`  | installer smoke test     |
-| Piper (piper1-gpl) | local  | no             | yes     | `install-piper.ps1`      | installer smoke test     |
-| Kokoro TTS         | local  | no             | yes     | `install-kokoro.ps1`     | installer smoke test     |
-| Pocket TTS         | local  | no             | yes     | `install-pocket.ps1`     | installer smoke test     |
-| Chatterbox         | local  | no             | yes     | `install-chatterbox.ps1` | installer smoke test     |
-| HTTP server        | either | varies         | varies  | — (configure in profile) | —                        |
+| Cartesia (Sonic)   | cloud  | yes            | no      | —                              | `test_tts_engine_config` |
+| ElevenLabs         | cloud  | yes            | no      | —                              | `test_tts_engine_config` |
+| OpenAI             | cloud  | yes            | no      | —                              | `test_tts_engine_config` |
+| Google Gemini TTS  | cloud  | yes            | no      | —                              | `test_tts_engine_config` |
+| Microsoft / Azure  | cloud  | yes + endpoint | no      | —                              | `test_tts_engine_config` |
+| Kitten TTS         | local  | no             | yes     | `install-kittentts.ps1`        | installer smoke test     |
+| Piper (piper1-gpl) | local  | no             | yes     | `install-piper.ps1`            | installer smoke test     |
+| Kokoro TTS         | local  | no             | yes     | `install-kokoro.ps1`           | installer smoke test     |
+| Pocket TTS         | local  | no             | yes     | `install-pocket.ps1`           | installer smoke test     |
+| Chatterbox         | local  | no             | yes     | `install-chatterbox.ps1`       | installer smoke test     |
+| HTTP server        | either | varies         | varies  | — (configure in profile)       | —                        |
 
 ## Cloud engines
 

--- a/docs_internal/architecture.md
+++ b/docs_internal/architecture.md
@@ -301,7 +301,7 @@ Rune-based stores in `src/lib/stores/` (`playback-store`, `synthesis-store`, `hu
 4. Optional LLM post-processing (Groq rewrite for listening)
 5. Pagination (if enabled): split into fragments → fragment_queue
 6. tts/ synthesizes (subprocess or HTTPS) → bytes
-7. audio/ plays via rodio (volume, speed, pitch)
+7. WebView plays the audio (volume; speed and pitch via `TimeStretcher`, independent knobs)
 8. Effects applied per-profile (OfflineAudioContext in the WebView)
 9. history/ logs entry; HUD shows waveform; telemetry records duration
 10. Frontend refreshes via history-updated / audio-ready events
@@ -310,6 +310,8 @@ Rune-based stores in `src/lib/stores/` (`playback-store`, `synthesis-store`, `hu
 ## Voice Profiles
 
 Named presets (`engine + voice + speed + pitch + effects`) managed by `profile-manager.svelte`, applied via `set_active_profile` / `speak_now_with_profile`. Effects live on the profile (`VoiceProfile.effects`), not in global config. Profiles export/import via `profile-export-dialog`.
+
+`speed` (0.5-2.0) and `pitch` (0.75-1.35) are independent: speed time-stretches without shifting pitch, pitch shifts without changing duration. Both ranges live in `config/tts.rs` (`SPEED_RANGE`, `PITCH_RANGE`) and are clamped on config load. The streaming PCM path stretches each chunk in `playback/time-stretch.ts` before scheduling; the `<audio>` path bakes the pitch shift into the blob and leaves speed to `preservesPitch` + `playbackRate`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CopySpeak",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "A simple and configurable AI-generated Text-to-Speech (TTS) orchestrator for Windows",
   "type": "module",
   "scripts": {
@@ -25,6 +25,7 @@
   "dependencies": {
     "@fontsource/lato": "^5.2.7",
     "@lucide/svelte": "^1.23.0",
+    "@soundtouchjs/core": "^2.1.1",
     "@tauri-apps/api": "^2.11",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copyspeak"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "CopySpeak - AI text-to-speech orchestrator"
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod wav;
 // Re-export all public types so external code can use `crate::audio::*` unchanged.
 pub use format::convert_audio_format;
 pub use player::{AudioPlayer, PlaybackState};
-pub use wav::{concat_wav_files, extract_envelope};
+pub use wav::extract_envelope;
 
 /// Pre-computed amplitude envelope for HUD waveform visualization.
 /// Contains N normalized RMS values (0.0–1.0) evenly spaced across the audio duration.

--- a/src-tauri/src/audio/wav.rs
+++ b/src-tauri/src/audio/wav.rs
@@ -1,4 +1,4 @@
-// WAV file parsing, PCM sample reading, amplitude envelope extraction, and concatenation.
+// WAV file parsing, PCM sample reading, and amplitude envelope extraction.
 
 use super::AmplitudeEnvelope;
 
@@ -324,74 +324,4 @@ pub fn extract_envelope(audio_bytes: &[u8], num_bars: usize) -> Result<Amplitude
         values: normalized,
         duration_ms,
     })
-}
-
-/// Find the start of the "data" chunk payload in a WAV file.
-/// Returns the byte offset where raw PCM data begins (after "data" + 4-byte size field).
-pub(super) fn find_wav_data_offset(wav: &[u8]) -> Option<usize> {
-    if wav.len() < 12 || &wav[0..4] != b"RIFF" || &wav[8..12] != b"WAVE" {
-        return None;
-    }
-    let mut pos = 12usize;
-    while pos + 8 <= wav.len() {
-        let chunk_id = &wav[pos..pos + 4];
-        let chunk_size =
-            u32::from_le_bytes([wav[pos + 4], wav[pos + 5], wav[pos + 6], wav[pos + 7]]) as usize;
-        if chunk_id == b"data" {
-            return Some(pos + 8); // byte offset right after "data" + 4-byte size
-        }
-        pos += 8 + chunk_size;
-        if chunk_size % 2 != 0 {
-            pos += 1;
-        } // WAV chunks are word-aligned
-    }
-    None
-}
-
-/// Concatenate multiple PCM WAV buffers into a single valid WAV.
-/// All buffers must share the same sample rate, channels, and bit depth.
-/// Returns the first buffer unchanged if the slice has only one element.
-pub fn concat_wav_files(wavs: Vec<Vec<u8>>) -> Result<Vec<u8>, String> {
-    match wavs.len() {
-        0 => return Err("No audio fragments to concatenate".to_string()),
-        1 => return Ok(wavs.into_iter().next().unwrap()),
-        _ => {}
-    }
-
-    let first = &wavs[0];
-    let first_data_offset =
-        find_wav_data_offset(first).ok_or("First audio fragment is not a valid WAV file")?;
-
-    // Everything before the "data" chunk identifier (RIFF header + fmt chunk + other chunks)
-    let prefix_end = first_data_offset - 8; // back up past "data" (4) + data_size (4)
-
-    // Collect raw PCM from all fragments
-    let mut all_pcm: Vec<u8> = first[first_data_offset..].to_vec();
-    for (idx, wav) in wavs[1..].iter().enumerate() {
-        match find_wav_data_offset(wav) {
-            Some(offset) => all_pcm.extend_from_slice(&wav[offset..]),
-            None => log::warn!("[Audio] Fragment {} is not a valid WAV, skipping", idx + 1),
-        }
-    }
-
-    // Build combined WAV
-    let mut output: Vec<u8> = Vec::with_capacity(prefix_end + 8 + all_pcm.len());
-    output.extend_from_slice(b"RIFF");
-    output.extend_from_slice(&[0u8; 4]); // RIFF size placeholder
-    output.extend_from_slice(&first[8..prefix_end]); // "WAVE" + fmt chunk
-    output.extend_from_slice(b"data");
-    output.extend_from_slice(&(all_pcm.len() as u32).to_le_bytes());
-    output.extend_from_slice(&all_pcm);
-
-    // Fix RIFF chunk size (total file size - 8 for the "RIFF" + size fields)
-    let riff_size = (output.len() - 8) as u32;
-    output[4..8].copy_from_slice(&riff_size.to_le_bytes());
-
-    log::debug!(
-        "[Audio] Concatenated {} WAV fragments into {} bytes",
-        wavs.len(),
-        output.len()
-    );
-
-    Ok(output)
 }

--- a/src-tauri/src/commands/playback.rs
+++ b/src-tauri/src/commands/playback.rs
@@ -123,14 +123,15 @@ pub fn skip_backward(
     Ok(())
 }
 
-/// Set the playback speed (0.25–4.0) on the active profile.
-/// Saved to config; applied by frontend audio element.
+/// Set the playback speed on the active profile, clamped to `SPEED_RANGE`.
+/// Saved to config; applied by the frontend, which time-stretches rather than
+/// resampling, so speed never shifts pitch.
 #[tauri::command]
 pub fn set_playback_speed(config: State<'_, Mutex<AppConfig>>, speed: f32) -> Result<(), String> {
     if crate::logging::is_debug_mode() {
         log::debug!("[IPC] set_playback_speed called (speed: {})", speed);
     }
-    let clamped = speed.clamp(0.25, 4.0);
+    let clamped = speed.clamp(crate::config::SPEED_RANGE.0, crate::config::SPEED_RANGE.1);
     let mut cfg = config.lock().unwrap();
     let active_id = cfg.tts.active_profile_id.clone();
     if let Some(profile) = cfg.tts.profiles.iter_mut().find(|p| p.id == active_id) {

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -292,6 +292,17 @@ fn migrate_add_kitten_profile_v4(cfg: &mut AppConfig) {
     log::info!("Config migrated to schema v4 (add bundled Kitten profile)");
 }
 
+/// Bring every profile's speed and pitch back inside the supported ranges.
+/// Profiles saved before speed and pitch became independent knobs could carry a
+/// pitch of up to 2.0, which is a full octave once it no longer also changes
+/// speed. Not a schema change, so no version bump.
+fn clamp_profile_rates(cfg: &mut AppConfig) {
+    for profile in cfg.tts.profiles.iter_mut() {
+        profile.speed = profile.speed.clamp(tts::SPEED_RANGE.0, tts::SPEED_RANGE.1);
+        profile.pitch = profile.pitch.clamp(tts::PITCH_RANGE.0, tts::PITCH_RANGE.1);
+    }
+}
+
 /// Returns the config file path: %APPDATA%/CopySpeak/config.json
 pub fn config_path() -> PathBuf {
     let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
@@ -321,6 +332,8 @@ pub fn load_or_default() -> AppConfig {
             if cfg.tts.schema_version < 4 {
                 migrate_add_kitten_profile_v4(&mut cfg);
             }
+
+            clamp_profile_rates(&mut cfg);
 
             cfg
         }

--- a/src-tauri/src/config/tts.rs
+++ b/src-tauri/src/config/tts.rs
@@ -757,6 +757,13 @@ impl<'de> Deserialize<'de> for ProfileEngineOptions {
     }
 }
 
+/// Playback speed bounds. Speed time-stretches without shifting pitch, so the
+/// ceiling is about intelligibility rather than artefacts.
+pub const SPEED_RANGE: (f32, f32) = (0.5, 2.0);
+/// Pitch-shift bounds, roughly -5 to +5 semitones. Wide enough to be clearly
+/// audible, narrow enough that the voice stays human.
+pub const PITCH_RANGE: (f32, f32) = (0.75, 1.35);
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct VoiceProfile {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "CopySpeak",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "identifier": "com.copyspeak.tts",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/engine/profile-export-dialog.svelte
+++ b/src/lib/components/engine/profile-export-dialog.svelte
@@ -148,8 +148,7 @@
         <textarea
           readonly
           class="bg-muted/50 border-border focus:ring-ring h-64 w-full resize-none rounded-md border p-3 font-mono text-xs focus:ring-2 focus:outline-none"
-          value={exportJson}
-        ></textarea>
+          value={exportJson}></textarea>
       </div>
       <div class="border-border flex justify-end gap-2 border-t p-4">
         <Button variant="outline" onclick={onClose}>Close</Button>
@@ -179,8 +178,7 @@
         <textarea
           class="bg-background border-border focus:ring-ring h-48 w-full resize-none rounded-md border p-3 font-mono text-xs focus:ring-2 focus:outline-none"
           placeholder="Paste profile JSON here..."
-          bind:value={importJson}
-        ></textarea>
+          bind:value={importJson}></textarea>
 
         {#if importError}
           <div class="text-destructive bg-destructive/10 rounded-md p-3 text-sm">

--- a/src/lib/components/engine/profile-manager.svelte
+++ b/src/lib/components/engine/profile-manager.svelte
@@ -203,6 +203,11 @@
   const activeId = $derived(localConfig.tts.active_profile_id);
   const activeIndex = $derived(profiles.findIndex((p: VoiceProfile) => p.id === activeId));
   const active = $derived(activeIndex >= 0 ? profiles[activeIndex] : null);
+
+  // Live drag values: shown while a slider is dragged, cleared on commit so the
+  // profile becomes the source of truth again (also handles profile switching).
+  let speedLive = $state<number | null>(null);
+  let pitchLive = $state<number | null>(null);
   const profileOptions = $derived(
     profiles.map((p: VoiceProfile) => ({ value: p.id, label: p.name }))
   );
@@ -563,9 +568,7 @@
 
 <div>
   <!-- Header: title + actions -->
-  <div
-    class="border-border flex flex-wrap items-center justify-between gap-3 border-b pb-4"
-  >
+  <div class="border-border flex flex-wrap items-center justify-between gap-3 border-b pb-4">
     <div>
       <h2 class="text-lg font-semibold">Voice Profiles</h2>
       <p class="text-muted-foreground mt-1 text-sm">
@@ -715,28 +718,36 @@
         <SettingRow label="Speed">
           <div class="flex w-56 items-center gap-2">
             <span class="text-muted-foreground w-12 shrink-0 text-right text-xs tabular-nums">
-              {active.speed.toFixed(2)}x
+              {(speedLive ?? active.speed).toFixed(2)}x
             </span>
             <Slider
               value={active.speed}
               min={0.5}
               max={2}
               step={0.05}
-              onchange={(v) => (localConfig.tts.profiles[activeIndex].speed = v)}
+              oninput={(v) => (speedLive = v)}
+              onchange={(v) => {
+                localConfig.tts.profiles[activeIndex].speed = v;
+                speedLive = null;
+              }}
             />
           </div>
         </SettingRow>
         <SettingRow label="Pitch">
           <div class="flex w-56 items-center gap-2">
             <span class="text-muted-foreground w-12 shrink-0 text-right text-xs tabular-nums">
-              {active.pitch.toFixed(2)}x
+              {(pitchLive ?? active.pitch).toFixed(2)}x
             </span>
             <Slider
               value={active.pitch}
-              min={0.5}
-              max={2}
-              step={0.05}
-              onchange={(v) => (localConfig.tts.profiles[activeIndex].pitch = v)}
+              min={0.75}
+              max={1.35}
+              step={0.01}
+              oninput={(v) => (pitchLive = v)}
+              onchange={(v) => {
+                localConfig.tts.profiles[activeIndex].pitch = v;
+                pitchLive = null;
+              }}
             />
           </div>
         </SettingRow>

--- a/src/lib/components/quick-settings.svelte
+++ b/src/lib/components/quick-settings.svelte
@@ -25,6 +25,11 @@
   const profilePitch = $derived(activeProfile?.pitch ?? 1.0);
   const profileEffectsEnabled = $derived(activeProfile?.effects.enabled ?? false);
 
+  // Live drag values: shown while a slider is dragged, cleared on commit so the
+  // profile becomes the source of truth again (also handles profile switching).
+  let speedLive = $state<number | null>(null);
+  let pitchLive = $state<number | null>(null);
+
   // Toggle clipboard listener on/off — delegates to the store which manages the Tauri backend
   async function handleToggle() {
     await listeningStore.toggle();
@@ -86,7 +91,7 @@
     <div class="flex min-w-0 flex-col gap-2 py-2">
       <div class="flex items-center justify-between">
         <Label for="qs-speed" class="text-sm">Speed</Label>
-        <span class="text-muted-foreground text-xs">{profileSpeed.toFixed(2)}x</span>
+        <span class="text-muted-foreground text-xs">{(speedLive ?? profileSpeed).toFixed(2)}x</span>
       </div>
       <Slider
         id="qs-speed"
@@ -95,8 +100,10 @@
         max={2}
         step={0.05}
         value={profileSpeed}
+        oninput={(v) => (speedLive = v)}
         onchange={(v) => {
           if (activeProfile) activeProfile.speed = v;
+          speedLive = null;
         }}
       />
     </div>
@@ -104,17 +111,19 @@
     <div class="flex min-w-0 flex-col gap-2 py-2">
       <div class="flex items-center justify-between">
         <Label for="qs-pitch" class="text-sm">Pitch</Label>
-        <span class="text-muted-foreground text-xs">{profilePitch.toFixed(2)}x</span>
+        <span class="text-muted-foreground text-xs">{(pitchLive ?? profilePitch).toFixed(2)}x</span>
       </div>
       <Slider
         id="qs-pitch"
         disabled={!activeProfile}
-        min={0.5}
-        max={2}
-        step={0.05}
+        min={0.75}
+        max={1.35}
+        step={0.01}
         value={profilePitch}
+        oninput={(v) => (pitchLive = v)}
         onchange={(v) => {
           if (activeProfile) activeProfile.pitch = v;
+          pitchLive = null;
         }}
       />
     </div>

--- a/src/lib/components/recent-history.test.ts
+++ b/src/lib/components/recent-history.test.ts
@@ -8,9 +8,13 @@ vi.mock("@tauri-apps/plugin-opener", () => ({ revealItemInDir: vi.fn() }));
 vi.mock("$lib/stores/history-store.svelte.js", () => ({
   historyStore: {
     items: Array.from({ length: 6 }, (_, index) => ({
-      id: String(index), timestamp: Date.now() - index * 60_000,
-      text: `Reading ${index}`, tts_engine: "cartesia", voice: "saved",
-      success: true, output_path: `/audio/${index}.wav`
+      id: String(index),
+      timestamp: Date.now() - index * 60_000,
+      text: `Reading ${index}`,
+      tts_engine: "cartesia",
+      voice: "saved",
+      success: true,
+      output_path: `/audio/${index}.wav`
     }))
   }
 }));
@@ -20,7 +24,8 @@ it("scrolls the five-reading preview sideways with the wheel and ends with Histo
   const view = render(RecentHistory, { compact: true, limit: 5 });
   const rail = view.getByRole("list");
   Object.defineProperties(rail, {
-    scrollWidth: { value: 1600 }, clientWidth: { value: 600 }
+    scrollWidth: { value: 1600 },
+    clientWidth: { value: 600 }
   });
   const wheel = new WheelEvent("wheel", { deltaY: 100, cancelable: true });
   rail.dispatchEvent(wheel);

--- a/src/lib/components/settings/appearance-settings.svelte
+++ b/src/lib/components/settings/appearance-settings.svelte
@@ -21,9 +21,7 @@
 
   function handleThemeChange(e: Event) {
     localConfig.general.appearance = (e.target as HTMLSelectElement).value as
-      | "system"
-      | "light"
-      | "dark";
+      "system" | "light" | "dark";
   }
 
   function handleLocaleChange(e: Event) {

--- a/src/lib/components/settings/batch-settings.svelte
+++ b/src/lib/components/settings/batch-settings.svelte
@@ -35,8 +35,7 @@
         class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-20 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         placeholder="Enter text snippets, one per line..."
         bind:value={batchTexts}
-        disabled={isBatchProcessing}
-      ></textarea>
+        disabled={isBatchProcessing}></textarea>
     </div>
 
     <!-- Output settings -->

--- a/src/lib/components/settings/import-export-settings.svelte
+++ b/src/lib/components/settings/import-export-settings.svelte
@@ -183,8 +183,7 @@
         <textarea
           readonly
           class="bg-muted/50 border-border focus:ring-ring h-64 w-full resize-none rounded-md border p-3 font-mono text-xs focus:ring-2 focus:outline-none"
-          value={exportJson}
-        ></textarea>
+          value={exportJson}></textarea>
       </div>
 
       <div class="border-border flex justify-end gap-2 border-t p-4">
@@ -232,8 +231,7 @@
         <textarea
           class="bg-background border-border focus:ring-ring h-48 w-full resize-none rounded-md border p-3 font-mono text-xs focus:ring-2 focus:outline-none"
           placeholder="Paste settings JSON here..."
-          bind:value={importJson}
-        ></textarea>
+          bind:value={importJson}></textarea>
 
         {#if importError}
           <div class="text-destructive bg-destructive/10 rounded-md p-3 text-sm">

--- a/src/lib/components/settings/post-process-settings.svelte
+++ b/src/lib/components/settings/post-process-settings.svelte
@@ -122,8 +122,7 @@ Text:
           id="groq-prompt"
           rows="10"
           class="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring w-full rounded-md border px-3 py-2 font-mono text-xs focus-visible:ring-1 focus-visible:outline-none"
-          bind:value={localConfig.post_process.prompt}
-        ></textarea>
+          bind:value={localConfig.post_process.prompt}></textarea>
         <p class="text-muted-foreground text-xs">{$_("settings.postProcess.promptHelp")}</p>
       </div>
     </div>

--- a/src/lib/components/ui/slider/slider.svelte
+++ b/src/lib/components/ui/slider/slider.svelte
@@ -2,7 +2,7 @@
   import { cn } from "$lib/utils.js";
   import type { HTMLAttributes } from "svelte/elements";
 
-  export type SliderProps = Omit<HTMLAttributes<HTMLDivElement>, "onchange"> & {
+  export type SliderProps = Omit<HTMLAttributes<HTMLDivElement>, "onchange" | "oninput"> & {
     class?: string;
     value?: number;
     min?: number;
@@ -13,6 +13,8 @@
     name?: string;
     "aria-label"?: string;
     onchange?: (value: number) => void;
+    /** Fires on every drag tick. Use for live display only; commit in onchange. */
+    oninput?: (value: number) => void;
   };
 </script>
 
@@ -28,6 +30,7 @@
     name,
     "aria-label": ariaLabel,
     onchange,
+    oninput,
     ...restProps
   }: SliderProps = $props();
 
@@ -47,6 +50,7 @@
     {step}
     {disabled}
     bind:value
+    oninput={() => oninput?.(value)}
     onchange={() => onchange?.(value)}
     aria-label={ariaLabel}
     data-slot="slider"

--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -19,5 +19,4 @@
     className
   )}
   bind:value
-  {...restProps}
-></textarea>
+  {...restProps}></textarea>

--- a/src/lib/models/history.test.ts
+++ b/src/lib/models/history.test.ts
@@ -1,5 +1,10 @@
 import { expect, it } from "vitest";
-import { createHistoryItem, groupHistoryReadings, historyVoiceLabel, historyTimeAgo } from "./history";
+import {
+  createHistoryItem,
+  groupHistoryReadings,
+  historyVoiceLabel,
+  historyTimeAgo
+} from "./history";
 import type { EngineCatalogEntry, VoiceProfile } from "$lib/types";
 
 it("shows elapsed time at minute, hour, and day boundaries", () => {

--- a/src/lib/stores/hud-store.svelte.ts
+++ b/src/lib/stores/hud-store.svelte.ts
@@ -87,8 +87,8 @@ let dotPulsing = $derived(isSynthesizing || (!isPaused && !isSynthesizing));
 let playbackProgressPercent = $derived(
   caption && caption.duration_ms > 0
     ? Math.min(100, (caption.position_ms / caption.duration_ms) * 100)
-    : accurateDurationMs !== null && accurateDurationMs > 0 && pitch > 0 && speed > 0
-      ? Math.min(100, (playbackElapsedMs / (accurateDurationMs / (pitch * speed))) * 100)
+    : accurateDurationMs !== null && accurateDurationMs > 0 && speed > 0
+      ? Math.min(100, (playbackElapsedMs / (accurateDurationMs / speed)) * 100)
       : 0
 );
 
@@ -188,8 +188,9 @@ export const hudStore = {
   },
   get adjustedDurationMs() {
     if (accurateDurationMs === null || accurateDurationMs <= 0) return 0;
-    if (pitch <= 0 || speed <= 0) return 0;
-    return accurateDurationMs / (pitch * speed);
+    if (speed <= 0) return 0;
+    // Pitch shifting preserves duration; only speed changes it.
+    return accurateDurationMs / speed;
   },
   get isPlaybackReady() {
     return isPlaybackReady;

--- a/src/lib/stores/playback-store.svelte.ts
+++ b/src/lib/stores/playback-store.svelte.ts
@@ -14,6 +14,7 @@ import type { EffectId } from "$lib/types";
 import { applyFadeIn, audioBufferToWavBlob, detectAudioMimeType } from "./playback/audio-utils.js";
 import { AudioAnalyser } from "./playback/analyser.js";
 import { PcmStreamScheduler, type StreamChunkPayload } from "./playback/pcm-stream.js";
+import { stretchBuffer } from "./playback/time-stretch.js";
 import { getEffect } from "./playback/effects/registry.js";
 import { FragmentQueue, type QueuedFragment } from "./playback/fragment-queue.js";
 import { hudStore } from "./hud-store.svelte.js";
@@ -53,7 +54,6 @@ class PlaybackStore {
   private _playbackGeneration = 0;
   private _readingText = "";
   private _fragmentCaptions: CaptionAlignment | null = null;
-  private _renderedPitch = 1;
   private _streamStopped = false;
   private _fragmentText = "";
   private _captionTimer: ReturnType<typeof setInterval> | null = null;
@@ -147,12 +147,12 @@ class PlaybackStore {
       const el = this._audioEl;
       const duration = Number.isFinite(el.duration)
         ? el.duration
-        : (this._decodedBuffer?.duration ?? 0) / this._renderedPitch;
+        : (this._decodedBuffer?.duration ?? 0);
       caption = {
         text: this._fragmentCaptions?.text ?? (this._fragmentText || this._readingText),
         captions: this._fragmentCaptions,
-        position_ms: el.currentTime * this._renderedPitch * 1000,
-        duration_ms: duration * this._renderedPitch * 1000,
+        position_ms: el.currentTime * 1000,
+        duration_ms: duration * 1000,
         paused: this.isPaused,
         active: !this.isLoadingAudio && !el.ended && !el.seeking && el.readyState >= 2
       };
@@ -195,18 +195,8 @@ class PlaybackStore {
           buffer.copyToChannel(this._decodedBuffer.getChannelData(c), c);
         }
       } else {
-        const outputLen = Math.max(1, Math.round(this._decodedBuffer.length / pitchRatio));
-        const offline = new OfflineAudioContext(
-          this._decodedBuffer.numberOfChannels,
-          outputLen,
-          this._decodedBuffer.sampleRate
-        );
-        const src = offline.createBufferSource();
-        src.buffer = this._decodedBuffer;
-        src.playbackRate.value = pitchRatio;
-        src.connect(offline.destination);
-        src.start(0);
-        buffer = await offline.startRendering();
+        // Pitch shift only - duration stays native so caption positions map 1:1.
+        buffer = stretchBuffer(this._decodedBuffer, 1, pitchRatio);
       }
       if (effect) {
         buffer = await effect.process(buffer, this._audioCtx);
@@ -268,11 +258,9 @@ class PlaybackStore {
         // Emit to HUD window for cross-window state sync
         this._emit?.("hud:audio-duration", accurateDurationMs);
       }
-      const renderedPitch = this.pitch;
-      const url = await this.buildPlaybackUrl(renderedPitch);
+      const url = await this.buildPlaybackUrl(this.pitch);
       if (generation !== this._playbackGeneration) return;
       if (!this._audioEl || !url) throw new Error("Audio player is not ready");
-      this._renderedPitch = renderedPitch;
       this._audioEl.src = url;
       this._analyser.start(); // Start amplitude capture BEFORE audio plays
       await this.playAudio();
@@ -394,6 +382,8 @@ class PlaybackStore {
       throw new Error("Audio player is not ready");
     }
     this._audioEl.volume = this.volume / 100;
+    // Time-stretch rather than resample, so speed never shifts pitch.
+    this._audioEl.preservesPitch = true;
     this._audioEl.playbackRate = this.speed;
     console.log(
       "[PlaybackStore] playAudio: volume",
@@ -409,10 +399,8 @@ class PlaybackStore {
   async handleReplay(): Promise<void> {
     this.historyReadingId = null;
     if (!this._audioEl) return;
-    const renderedPitch = this.pitch;
-    const url = await this.buildPlaybackUrl(renderedPitch);
+    const url = await this.buildPlaybackUrl(this.pitch);
     if (url) {
-      this._renderedPitch = renderedPitch;
       this._audioEl.src = url;
       this._audioEl.currentTime = 0;
       try {
@@ -486,6 +474,7 @@ class PlaybackStore {
     }
     if (this._audioEl) {
       this._audioEl.volume = volume / 100;
+      this._audioEl.preservesPitch = true;
       this._audioEl.playbackRate = speed;
     }
     // Keep the streaming scheduler in sync while it owns playback

--- a/src/lib/stores/playback-store.test.ts
+++ b/src/lib/stores/playback-store.test.ts
@@ -146,9 +146,14 @@ it("publishes captions from the audio clock and audible fragment, then stops pub
   expect(emitTo).not.toHaveBeenCalled();
 });
 
-it.each([0.5, Number.NaN])(
+// The rendered blob carries native duration - pitch shifting no longer resamples
+// it - so the media clock is already caption time, with no correction factor.
+it.each([
+  [0.5, 500],
+  [Number.NaN, 1000]
+])(
   "replays native timings through pitch, speed, and pause (duration %s)",
-  async (duration) => {
+  async (duration, expectedDurationMs) => {
     vi.useFakeTimers();
     vi.spyOn(audio, "readyState", "get").mockReturnValue(4);
     vi.spyOn(audio, "duration", "get").mockReturnValue(duration);
@@ -179,8 +184,8 @@ it.each([0.5, Number.NaN])(
       "hud:caption",
       expect.objectContaining({
         captions,
-        position_ms: 600,
-        duration_ms: 1000
+        position_ms: 300,
+        duration_ms: expectedDurationMs
       })
     );
     audio.dispatchEvent(new Event("pause"));
@@ -188,7 +193,7 @@ it.each([0.5, Number.NaN])(
     expect(emitTo).toHaveBeenLastCalledWith(
       "hud",
       "hud:caption",
-      expect.objectContaining({ captions, position_ms: 600, paused: true })
+      expect.objectContaining({ captions, position_ms: 300, paused: true })
     );
     playbackStore.syncPlaybackConfig(100, 1, 1);
   }

--- a/src/lib/stores/playback/pcm-stream.test.ts
+++ b/src/lib/stores/playback/pcm-stream.test.ts
@@ -118,13 +118,15 @@ describe("PcmStreamScheduler", () => {
     expect(scheduler.getPlaybackPosition()).toBeNull();
   });
 
-  it("measures source time across playback rate changes", () => {
+  it("keeps audible audio at the rate it was rendered at", () => {
     const { scheduler, ctx } = createHarness();
     scheduler.handleChunk(chunk(new Uint8Array(48000)));
     ctx.currentTime = 0.28;
     scheduler.setRate(2, 1);
+    // The audible source was time-stretched at speed 1 and cannot be retuned in
+    // place, so its clock keeps advancing one native second per wall second.
     ctx.currentTime = 0.53;
-    expect(scheduler.getPlaybackPosition()?.positionMs).toBeCloseTo(750);
+    expect(scheduler.getPlaybackPosition()?.positionMs).toBeCloseTo(500);
     scheduler.stop();
   });
 
@@ -136,10 +138,16 @@ describe("PcmStreamScheduler", () => {
     oldFuture.stop = vi.fn();
     ctx.currentTime = 0.53;
     scheduler.setRate(rate, 1);
-    const expectedStart = 0.53 + 0.5 / rate;
+    // The audible source still owes 0.5s of native audio at its rendered rate.
+    const expectedStart = 1.03;
     expect(oldFuture.stop).toHaveBeenCalledOnce();
     expect(oldFuture.onended).toBeNull();
     expect(sources[2].at).toBeCloseTo(expectedStart);
+    // The requeued chunk is re-stretched, so one native second now occupies
+    // 1/rate wall seconds of buffer, minus the WSOLA window still held back
+    // until the fragment is flushed.
+    expect(sources[2].buffer!.duration).toBeGreaterThan(0.75 / rate);
+    expect(sources[2].buffer!.duration).toBeLessThanOrEqual(1.02 / rate);
     ctx.currentTime = expectedStart + 0.1;
     expect(scheduler.getPlaybackPosition()?.fragmentIndex).toBe(1);
     expect(scheduler.getPlaybackPosition()?.positionMs).toBeCloseTo(100 * rate);

--- a/src/lib/stores/playback/pcm-stream.ts
+++ b/src/lib/stores/playback/pcm-stream.ts
@@ -6,6 +6,7 @@
  * shared AudioContext so speech starts while synthesis is still running
  * (~250ms prebuffer) and continues back-to-back without clicks or gaps.
  */
+import { TimeStretcher, type PcmChannel } from "./time-stretch";
 
 /** Payload of one `audio-stream-chunk` event (matches AudioStreamChunkEvent). */
 export interface StreamChunkPayload {
@@ -26,13 +27,28 @@ export interface StreamChunkPayload {
   captions?: import("$lib/models/captions").CaptionAlignment | null;
 }
 
+/** One decoded chunk of native-rate PCM, still unstretched. */
+interface PendingChunk {
+  channels: PcmChannel[];
+  /** Native seconds of audio this chunk carries. */
+  duration: number;
+  sampleRate: number;
+  fragmentIndex: number;
+}
+
 interface ScheduledPosition {
   fragmentIndex: number;
+  /** Native seconds into the fragment where this source's audio begins. */
   offset: number;
+  /** Native seconds of audio this source carries. */
   duration: number;
+  /** Native seconds already played. */
   consumed: number;
   clock: number;
+  /** Native seconds consumed per wall second - the speed this audio was rendered at. */
   rate: number;
+  /** Source chunk, for re-stretching if the rate changes before this starts. */
+  native: PendingChunk | null;
 }
 
 export interface PcmStreamSchedulerOptions {
@@ -95,9 +111,13 @@ export function pcm16LeToFloat32Channels(
  *
  * Chunks accumulate until ~250ms is buffered, then playback starts; every
  * later chunk is scheduled at a running nextStartTime cursor that self-heals
- * to currentTime after an underrun. Volume routes through a GainNode; speed
- * and pitch map to source.playbackRate (same audible effect as the batch
- * path's element rate plus resampled pitch).
+ * to currentTime after an underrun. Volume routes through a GainNode.
+ *
+ * Speed and pitch are independent: chunks pass through a {@link TimeStretcher}
+ * before scheduling, so `playbackRate` stays at 1 and every source plays at its
+ * natural rate. Positions are tracked in *native* seconds - `duration` and
+ * `offset` describe the source audio, and `rate` is the speed the audio was
+ * rendered at, which is what converts wall time back to caption time.
  */
 export class PcmStreamScheduler {
   private readonly _ctx: AudioContext;
@@ -105,16 +125,23 @@ export class PcmStreamScheduler {
   private readonly _onComplete: () => void;
 
   private _gain: GainNode;
-  private _pending: { buffer: AudioBuffer; fragmentIndex: number; offset: number }[] = [];
+  private _pending: PendingChunk[] = [];
   private _pendingDuration = 0;
   private _activeSources = new Map<AudioBufferSourceNode, ScheduledPosition>();
-  private _fragmentOffsets = new Map<number, number>();
   private _started = false;
   private _nextStartTime = 0;
   private _firstChunkAt: number | null = null;
   private _lastChunkAt: number | null = null;
   /** Transport boundaries need not coincide with a complete interleaved frame. */
   private _remainder: Uint8Array | null = null;
+
+  private _stretcher: TimeStretcher | null = null;
+  private _stretcherSampleRate = 0;
+  private _stretcherChannels = 0;
+  /** Fragment the scheduler is currently emitting audio for. */
+  private _scheduleFragment: number | null = null;
+  /** Native seconds of that fragment already scheduled. */
+  private _emittedNative = 0;
 
   private _volumePercent = 100;
   private _speed = 1.0;
@@ -147,42 +174,43 @@ export class PcmStreamScheduler {
   }
 
   /**
-   * Update speed and pitch. Applied immediately to already-scheduled sources;
-   * the scheduling cursor compensates using the current combined rate.
+   * Update speed and pitch. Audio already rendered keeps the rate it was
+   * rendered at; sources that have not started yet are dropped and their source
+   * chunks re-stretched, so a slider change lands within one audible chunk.
    */
   setRate(speed: number, pitch: number): void {
     if (!Number.isFinite(speed * pitch) || speed <= 0 || pitch <= 0) return;
-    const previousRate = this._combinedRate();
+    if (speed === this._speed && pitch === this._pitch) return;
     this._speed = speed;
     this._pitch = pitch;
-    const rate = speed * pitch;
-    if (rate === previousRate) return;
-    const future: typeof this._pending = [];
+    const requeued: PendingChunk[] = [];
+    let resumeOffset: number | null = null;
     this._nextStartTime = this._ctx.currentTime;
     for (const [source, position] of this._activeSources) {
       this._advancePosition(position);
-      if (position.clock > this._ctx.currentTime && source.buffer) {
-        // Absolute scheduled start times do not move when playbackRate changes.
-        // Requeue only unstarted sources; leave audible audio uninterrupted.
-        future.push({
-          buffer: source.buffer,
-          fragmentIndex: position.fragmentIndex,
-          offset: position.offset
-        });
+      if (position.clock > this._ctx.currentTime) {
+        // Absolute scheduled start times do not move, and the audio itself was
+        // rendered at the old rate. Re-stretch instead of rescheduling.
+        if (position.native) requeued.push(position.native);
+        resumeOffset =
+          resumeOffset === null ? position.offset : Math.min(resumeOffset, position.offset);
         source.onended = null;
         source.stop();
         this._activeSources.delete(source);
         continue;
       }
-      position.rate = rate;
-      source.playbackRate.value = rate;
       this._nextStartTime = Math.max(
         this._nextStartTime,
-        this._ctx.currentTime + (position.duration - position.consumed) / rate
+        this._ctx.currentTime + (position.duration - position.consumed) / position.rate
       );
     }
-    this._pending.unshift(...future);
-    this._pendingDuration += future.reduce((sum, item) => sum + item.buffer.duration, 0);
+    // ponytail: the stretcher's held-back window (<1 WSOLA frame) is discarded
+    // here; re-deriving it would need SoundTouch to expose its pending input.
+    this._stretcher?.reset();
+    this._stretcher?.setRate(speed, pitch);
+    if (resumeOffset !== null) this._emittedNative = resumeOffset;
+    this._pending.unshift(...requeued);
+    this._pendingDuration += requeued.reduce((sum, chunk) => sum + chunk.duration, 0);
     if (this._started) this._schedulePending();
   }
 
@@ -219,6 +247,7 @@ export class PcmStreamScheduler {
       // Flush short intermediate fragments without declaring the whole queue final.
       if (!this._started && this._pending.length) this._startPlayback();
       else this._schedulePending();
+      this._flushStretcher();
       this._remainder = null;
       return;
     }
@@ -251,7 +280,7 @@ export class PcmStreamScheduler {
         arrivalGapMs: this._lastChunkAt === null ? null : Math.round(now - this._lastChunkAt),
         bufferedMs: Math.round(
           1000 *
-            (this._pendingDuration / this._combinedRate() +
+            (this._pendingDuration / this._speed +
               Math.max(0, this._nextStartTime - this._ctx.currentTime))
         ),
         carriedBytes: remainderLength
@@ -261,15 +290,14 @@ export class PcmStreamScheduler {
     const channelData = pcm16LeToFloat32Channels(bytes, channels);
     if (channelData[0].length === 0) return;
 
-    const buffer = this._ctx.createBuffer(channels, channelData[0].length, payload.sample_rate);
-    for (let c = 0; c < channels; c++) {
-      buffer.copyToChannel(channelData[c], c);
-    }
-
-    const offset = this._fragmentOffsets.get(payload.fragment_index) ?? 0;
-    this._fragmentOffsets.set(payload.fragment_index, offset + buffer.duration);
-    this._pending.push({ buffer, fragmentIndex: payload.fragment_index, offset });
-    this._pendingDuration += buffer.duration;
+    const duration = channelData[0].length / payload.sample_rate;
+    this._pending.push({
+      channels: channelData,
+      duration,
+      sampleRate: payload.sample_rate,
+      fragmentIndex: payload.fragment_index
+    });
+    this._pendingDuration += duration;
 
     if (!this._started && this._pendingDuration >= PREBUFFER_SECONDS) {
       this._startPlayback();
@@ -293,6 +321,7 @@ export class PcmStreamScheduler {
     } else {
       this._schedulePending();
     }
+    this._flushStretcher();
     // Fallback completion if no explicit queue-complete signal follows
     // (covers multi-fragment synthesis gaps and the speak_now path).
     this._clearIdleTimer();
@@ -345,7 +374,6 @@ export class PcmStreamScheduler {
       }
     }
     this._activeSources.clear();
-    this._fragmentOffsets.clear();
     this._pending = [];
     this._pendingDuration = 0;
     this._started = false;
@@ -354,6 +382,9 @@ export class PcmStreamScheduler {
     this._lastChunkAt = null;
     this._remainder = null;
     this._pausedByUser = false;
+    this._stretcher = null;
+    this._scheduleFragment = null;
+    this._emittedNative = 0;
     try {
       this._gain.disconnect();
     } catch {
@@ -375,38 +406,80 @@ export class PcmStreamScheduler {
     this._schedulePending();
   }
 
-  private _combinedRate(): number {
-    return this._speed * this._pitch;
+  private _ensureStretcher(chunk: PendingChunk): TimeStretcher {
+    const channelCount = chunk.channels.length;
+    if (
+      !this._stretcher ||
+      this._stretcherSampleRate !== chunk.sampleRate ||
+      this._stretcherChannels !== channelCount
+    ) {
+      this._stretcher = new TimeStretcher(chunk.sampleRate, channelCount);
+      this._stretcherSampleRate = chunk.sampleRate;
+      this._stretcherChannels = channelCount;
+      this._stretcher.setRate(this._speed, this._pitch);
+    }
+    return this._stretcher;
+  }
+
+  /**
+   * Drain the stretcher's trailing window at a fragment boundary so the
+   * fragment's last word is not clipped, and restart native offsets at zero.
+   */
+  private _flushStretcher(): void {
+    if (!this._stretcher) return;
+    this._scheduleOutput(this._stretcher.flush(), this._stretcherSampleRate, null);
+    this._emittedNative = 0;
+    this._scheduleFragment = null;
   }
 
   private _schedulePending(): void {
-    const rate = this._combinedRate();
     while (this._pending.length > 0) {
-      const { buffer, fragmentIndex, offset } = this._pending.shift()!;
-      this._pendingDuration -= buffer.duration;
-      // Underrun tolerance: continue from currentTime if the cursor fell behind.
-      const at = Math.max(this._nextStartTime, this._ctx.currentTime + 0.005);
-      if (import.meta.env.DEV && at > this._nextStartTime) {
-        console.debug("[PcmStream] underrun", {
-          gapMs: Math.round(1000 * (at - this._nextStartTime))
-        });
+      const chunk = this._pending.shift()!;
+      this._pendingDuration -= chunk.duration;
+      if (this._scheduleFragment !== null && this._scheduleFragment !== chunk.fragmentIndex) {
+        this._flushStretcher();
       }
-      const source = this._ctx.createBufferSource();
-      source.buffer = buffer;
-      source.playbackRate.value = rate;
-      source.connect(this._gain);
-      source.onended = () => this._handleSourceEnded(source);
-      source.start(at);
-      this._activeSources.set(source, {
-        fragmentIndex,
-        offset,
-        duration: buffer.duration,
-        consumed: 0,
-        clock: at,
-        rate
-      });
-      this._nextStartTime = at + buffer.duration / rate;
+      const stretcher = this._ensureStretcher(chunk);
+      this._scheduleFragment = chunk.fragmentIndex;
+      this._scheduleOutput(stretcher.push(chunk.channels), chunk.sampleRate, chunk);
     }
+  }
+
+  /** Schedule one block of already-stretched audio at the running cursor. */
+  private _scheduleOutput(
+    channels: PcmChannel[] | null,
+    sampleRate: number,
+    native: PendingChunk | null
+  ): void {
+    if (!channels || channels[0].length === 0) return;
+    const buffer = this._ctx.createBuffer(channels.length, channels[0].length, sampleRate);
+    for (let c = 0; c < channels.length; c++) {
+      buffer.copyToChannel(channels[c], c);
+    }
+    // Underrun tolerance: continue from currentTime if the cursor fell behind.
+    const at = Math.max(this._nextStartTime, this._ctx.currentTime + 0.005);
+    if (import.meta.env.DEV && at > this._nextStartTime) {
+      console.debug("[PcmStream] underrun", {
+        gapMs: Math.round(1000 * (at - this._nextStartTime))
+      });
+    }
+    const source = this._ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(this._gain);
+    source.onended = () => this._handleSourceEnded(source);
+    source.start(at);
+    const nativeDuration = buffer.duration * this._speed;
+    this._activeSources.set(source, {
+      fragmentIndex: this._scheduleFragment ?? 0,
+      offset: this._emittedNative,
+      duration: nativeDuration,
+      consumed: 0,
+      clock: at,
+      rate: this._speed,
+      native
+    });
+    this._emittedNative += nativeDuration;
+    this._nextStartTime = at + buffer.duration;
   }
 
   private _handleSourceEnded(source: AudioBufferSourceNode): void {

--- a/src/lib/stores/playback/time-stretch.test.ts
+++ b/src/lib/stores/playback/time-stretch.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { concatTrim, TimeStretcher } from "./time-stretch";
+
+const SAMPLE_RATE = 24000;
+
+function sine(frames: number, hz: number): Float32Array<ArrayBuffer> {
+  const samples = new Float32Array(frames);
+  for (let i = 0; i < frames; i++) {
+    samples[i] = Math.sin((2 * Math.PI * hz * i) / SAMPLE_RATE);
+  }
+  return samples;
+}
+
+/** Zero crossings per second, a cheap stand-in for perceived pitch on a sine. */
+function crossingsPerSecond(samples: Float32Array): number {
+  let crossings = 0;
+  for (let i = 1; i < samples.length; i++) {
+    if (samples[i - 1] < 0 !== samples[i] < 0) crossings++;
+  }
+  return (crossings * SAMPLE_RATE) / samples.length;
+}
+
+/** Push a whole signal through in chunks, flush, and return the joined output. */
+function render(
+  input: Float32Array<ArrayBuffer>,
+  speed: number,
+  pitch: number,
+  chunkFrames = 4800
+): Float32Array {
+  const stretcher = new TimeStretcher(SAMPLE_RATE, 1);
+  stretcher.setRate(speed, pitch);
+  const parts: Float32Array[] = [];
+  for (let offset = 0; offset < input.length; offset += chunkFrames) {
+    const output = stretcher.push([input.slice(offset, offset + chunkFrames)]);
+    if (output) parts.push(output[0]);
+  }
+  const tail = stretcher.flush();
+  if (tail) parts.push(tail[0]);
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const joined = new Float32Array(total);
+  let written = 0;
+  for (const part of parts) {
+    joined.set(part, written);
+    written += part.length;
+  }
+  return joined;
+}
+
+describe("TimeStretcher", () => {
+  it("passes audio through untouched at speed 1 and pitch 1", () => {
+    const input = sine(SAMPLE_RATE, 440);
+    const stretcher = new TimeStretcher(SAMPLE_RATE, 1);
+    expect(stretcher.isBypassed).toBe(true);
+    expect(stretcher.push([input])?.[0]).toBe(input);
+    expect(stretcher.flush()).toBeNull();
+  });
+
+  // Pins the `pitch` setter + `stretch.tempo` override: SoundTouch derives
+  // tempo = 1 / pitch from the setter, and we replace it with speed / pitch.
+  it.each([0.5, 1.5, 2])("changes duration by speed %s without moving pitch", (speed) => {
+    const input = sine(2 * SAMPLE_RATE, 440);
+    const output = render(input, speed, 1);
+    expect(output.length / (input.length / speed)).toBeCloseTo(1, 1);
+    expect(crossingsPerSecond(output)).toBeCloseTo(880, -2);
+  });
+
+  it.each([0.75, 1.35])("changes pitch by %s without moving duration", (pitch) => {
+    const input = sine(2 * SAMPLE_RATE, 440);
+    const output = render(input, 1, pitch);
+    expect(output.length / input.length).toBeCloseTo(1, 1);
+    expect(crossingsPerSecond(output)).toBeCloseTo(880 * pitch, -2);
+  });
+
+  it("applies speed and pitch independently when combined", () => {
+    const input = sine(2 * SAMPLE_RATE, 440);
+    const output = render(input, 2, 1.35);
+    expect(output.length / (input.length / 2)).toBeCloseTo(1, 1);
+    expect(crossingsPerSecond(output)).toBeCloseTo(880 * 1.35, -2);
+  });
+
+  it("keeps stereo channels aligned", () => {
+    const stretcher = new TimeStretcher(SAMPLE_RATE, 2);
+    stretcher.setRate(1.5, 1);
+    const left = sine(SAMPLE_RATE, 440);
+    const right = sine(SAMPLE_RATE, 220);
+    const output = stretcher.push([left, right]);
+    expect(output).not.toBeNull();
+    expect(output![0].length).toBe(output![1].length);
+    expect(crossingsPerSecond(output![0])).toBeCloseTo(880, -2);
+    expect(crossingsPerSecond(output![1])).toBeCloseTo(440, -2);
+  });
+
+  it("drops nothing but silence when flushing a fragment tail", () => {
+    const input = sine(SAMPLE_RATE, 440);
+    const stretcher = new TimeStretcher(SAMPLE_RATE, 1);
+    stretcher.setRate(1.25, 1);
+    const body = stretcher.push([input])?.[0].length ?? 0;
+    const tail = stretcher.flush()?.[0].length ?? 0;
+    // Flush pads with silence but is capped at the frames the input is owed.
+    expect(body + tail).toBeLessThanOrEqual(Math.round(input.length / 1.25));
+    expect(body + tail).toBeGreaterThan(input.length / 1.25 - 0.05 * SAMPLE_RATE);
+  });
+});
+
+describe("concatTrim", () => {
+  it("truncates overflow and leaves shortfall silent", () => {
+    const parts = [[Float32Array.of(1, 2, 3)], null, [Float32Array.of(4, 5)]];
+    expect(Array.from(concatTrim(parts, 4, 1)[0])).toEqual([1, 2, 3, 4]);
+    expect(Array.from(concatTrim(parts, 7, 1)[0])).toEqual([1, 2, 3, 4, 5, 0, 0]);
+  });
+});

--- a/src/lib/stores/playback/time-stretch.ts
+++ b/src/lib/stores/playback/time-stretch.ts
@@ -1,0 +1,191 @@
+/**
+ * Independent playback speed and pitch, built on SoundTouch's WSOLA stretcher.
+ *
+ * `speed` changes duration only (output duration = native / speed, pitch
+ * untouched); `pitch` changes pitch only (duration untouched). Neither knob
+ * leaks into the other, which is what plain `playbackRate` resampling cannot do.
+ *
+ * SoundTouch's `pitch` setter derives `transposer.rate = pitch` and
+ * `stretch.tempo = 1 / pitch` - a pure pitch shift. Overriding `stretch.tempo`
+ * with `speed / pitch` right after keeps that pitch shift and folds the wanted
+ * duration change in: the transposer shortens by `pitch`, the stretch stage
+ * then lengthens by `pitch / speed`, leaving duration = native / speed.
+ */
+import { SoundTouch } from "@soundtouchjs/core";
+
+/** SoundTouch sample buffers are hard-coded to interleaved stereo frames. */
+const SAMPLES_PER_FRAME = 2;
+
+/** One channel of deinterleaved PCM, owning its buffer so it can back an AudioBuffer. */
+export type PcmChannel = Float32Array<ArrayBuffer>;
+
+/** Mono is duplicated into both frame slots; the second channel is dropped on the way out. */
+function interleave(channels: PcmChannel[]): Float32Array {
+  const left = channels[0];
+  const right = channels[1] ?? left;
+  const frames = left.length;
+  const interleaved = new Float32Array(frames * SAMPLES_PER_FRAME);
+  for (let frame = 0; frame < frames; frame++) {
+    interleaved[frame * SAMPLES_PER_FRAME] = left[frame];
+    interleaved[frame * SAMPLES_PER_FRAME + 1] = right[frame];
+  }
+  return interleaved;
+}
+
+function deinterleave(
+  interleaved: Float32Array,
+  frames: number,
+  channelCount: number
+): PcmChannel[] {
+  const channels: PcmChannel[] = Array.from(
+    { length: channelCount },
+    () => new Float32Array(frames)
+  );
+  for (let frame = 0; frame < frames; frame++) {
+    for (let c = 0; c < channelCount; c++) {
+      channels[c][frame] = interleaved[frame * SAMPLES_PER_FRAME + c];
+    }
+  }
+  return channels;
+}
+
+/**
+ * Copy `parts` into a single channel set of exactly `length` frames, truncating
+ * overflow and leaving any shortfall as silence.
+ */
+export function concatTrim(
+  parts: (PcmChannel[] | null)[],
+  length: number,
+  channelCount: number
+): PcmChannel[] {
+  const channels: PcmChannel[] = Array.from(
+    { length: channelCount },
+    () => new Float32Array(length)
+  );
+  let written = 0;
+  for (const part of parts) {
+    if (!part || written >= length) continue;
+    const take = Math.min(part[0].length, length - written);
+    for (let c = 0; c < channelCount; c++) {
+      channels[c].set(part[c].subarray(0, take), written);
+    }
+    written += take;
+  }
+  return channels;
+}
+
+/**
+ * Stateful stretcher for sequentially pushed PCM chunks.
+ *
+ * Output frames trail input: WSOLA holds back up to one window, so {@link push}
+ * returns `null` until enough has accumulated and {@link flush} is required at
+ * the end of a fragment to avoid clipping its last word.
+ */
+export class TimeStretcher {
+  private readonly _processor: SoundTouch;
+  private readonly _channelCount: number;
+  private _speed = 1;
+  private _pitch = 1;
+  /** Frames the current rate says should have been emitted for everything fed so far. */
+  private _expectedFrames = 0;
+  private _emittedFrames = 0;
+
+  constructor(sampleRate: number, channelCount: number) {
+    this._channelCount = Math.min(Math.max(channelCount, 1), 2);
+    this._processor = new SoundTouch({ sampleRate, sampleBufferType: "fifo" });
+    this.setRate(1, 1);
+  }
+
+  /** True when no processing is needed and chunks pass through untouched. */
+  get isBypassed(): boolean {
+    return this._speed === 1 && this._pitch === 1;
+  }
+
+  setRate(speed: number, pitch: number): void {
+    this._speed = speed;
+    this._pitch = pitch;
+    this._processor.pitch = pitch;
+    this._processor.stretch.tempo = speed / pitch;
+  }
+
+  /** Feed one chunk of native PCM; returns whatever output is ready, if any. */
+  push(channels: PcmChannel[]): PcmChannel[] | null {
+    const frames = channels[0]?.length ?? 0;
+    if (frames === 0) return null;
+    this._expectedFrames += frames / this._speed;
+    if (this.isBypassed) {
+      this._emittedFrames += frames;
+      return channels;
+    }
+    this._processor.inputBuffer.putSamples(interleave(channels));
+    this._processor.process();
+    return this._drain();
+  }
+
+  /**
+   * Push the trailing WSOLA window out with silence and reset. Output is capped
+   * at the frame count the pushed audio is owed, so the padding never becomes
+   * audible silence or drifts the caption clock.
+   */
+  flush(): PcmChannel[] | null {
+    if (this.isBypassed) {
+      this.reset();
+      return null;
+    }
+    // ponytail: pad generously rather than model the transposer's frame ratio;
+    // the owed-frames cap below discards whatever the padding over-produced.
+    const padFrames = Math.max(1, this._processor.stretch.sampleReq * 4);
+    this._processor.inputBuffer.putSamples(new Float32Array(padFrames * SAMPLES_PER_FRAME));
+    this._processor.process();
+    const drained = this._drain();
+    const owed =
+      Math.round(this._expectedFrames) - this._emittedFrames + (drained?.[0].length ?? 0);
+    this.reset();
+    if (!drained || owed <= 0) return null;
+    if (owed >= drained[0].length) return drained;
+    return drained.map((channel) => channel.slice(0, owed));
+  }
+
+  reset(): void {
+    this._processor.clear();
+    this._expectedFrames = 0;
+    this._emittedFrames = 0;
+  }
+
+  private _drain(): PcmChannel[] | null {
+    const frames = this._processor.outputBuffer.frameCount;
+    if (frames === 0) return null;
+    const interleaved = new Float32Array(frames * SAMPLES_PER_FRAME);
+    this._processor.outputBuffer.extract(interleaved, 0, frames);
+    this._processor.outputBuffer.receive(frames);
+    this._emittedFrames += frames;
+    return deinterleave(interleaved, frames, this._channelCount);
+  }
+}
+
+/**
+ * Whole-buffer variant for the non-streaming `<audio>` path. Output length is
+ * exactly `round(buffer.length / speed)`, so caption positions stay in a clean
+ * native-time relationship with the rendered audio.
+ */
+export function stretchBuffer(buffer: AudioBuffer, speed: number, pitch: number): AudioBuffer {
+  const channelCount = Math.min(buffer.numberOfChannels, 2);
+  const input: PcmChannel[] = Array.from({ length: channelCount }, (_, c) =>
+    buffer.getChannelData(c)
+  );
+  const stretcher = new TimeStretcher(buffer.sampleRate, channelCount);
+  stretcher.setRate(speed, pitch);
+  const body = stretcher.push(input);
+  const tail = stretcher.flush();
+  const length = Math.max(1, Math.round(buffer.length / speed));
+  const channels = concatTrim([body, tail], length, channelCount);
+  const output = new AudioBuffer({
+    length,
+    numberOfChannels: channelCount,
+    sampleRate: buffer.sampleRate
+  });
+  for (let c = 0; c < channelCount; c++) {
+    output.copyToChannel(channels[c], c);
+  }
+  return output;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,12 +28,7 @@ export type ValidationResult = ValidationError[];
 export type SupportedLocale = "en" | "es" | "ar" | "he";
 
 export type HudPresetPosition =
-  | "top-left"
-  | "top-center"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-center"
-  | "bottom-right";
+  "top-left" | "top-center" | "top-right" | "bottom-left" | "bottom-center" | "bottom-right";
 
 export type HudPosition = HudPresetPosition;
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.1.16";
+export const VERSION = "0.1.17";


### PR DESCRIPTION
## Summary
- Speed and pitch are now independent: SoundTouch WSOLA time-stretching (`playback/time-stretch.ts`) time-stretches speed while preserving pitch; pitch shifts without changing duration
- Streaming PCM scheduler stretches chunks before scheduling (`playbackRate` stays 1); `<audio>` path bakes pitch into the rendered blob and uses `preservesPitch`
- Speed range tightened to 0.5–2.0, pitch to 0.75–1.35; saved profiles clamped on load
- Removed dead WAV concatenation helpers from the pre-streaming batch path
- Version bump to 0.1.17, changelog updated

## Checks
- `bun run check`: 0 errors, 0 warnings
- `bun run test`: 61 passed (10 files)