### PR TITLE
feat(kokoro): native live captions via duration-capable ONNX model (v0.2.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 
 ## Active failure log
 
+- Pass Kokoro exporter options by their long names through `Invoke-Uv`; PowerShell binds `-o` as an ambiguous common parameter before uv runs.
+- Export Kokoro's duration-capable model under isolated Python 3.12; Kokoro 0.8.4's NumPy 1.x dependency cannot use the managed engine's Python 3.13 wheels.
 - Check credential presence without printing `.env` values; never grep secret files into command output.
 - Preserve native caption intervals with their generated audio through stream framing, cache/history replay, and sample-count-based fragment concatenation; never scale word timings by text weights.
 - Route playback speed and pitch through `TimeStretcher` (SoundTouch `pitch` setter, then `stretch.tempo = speed / pitch`); keep `playbackRate` at 1 on PCM sources and track `ScheduledPosition` duration/offset/rate in native time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-09-10
+
+### Changed
+
+- **Kokoro now has native live captions** — the local Kokoro engine reports `supports_captions: true`. The installer instead exports a duration-capable ONNX model (`kokoro-v1.0-duration.onnx`) using the pinned upstream exporter under an isolated Python 3.12 environment (Kokoro 0.8.4's NumPy 1.x dependency needs it), and installs `misaki[en]` for the English caption frontend. Existing audio-only installs show as needing reinstall; the old model is kept until the export succeeds.
+- **Engine options are no longer suffixed with "(no live captions)"** — the profile manager now relies on the catalog's caption warning instead of decorating the label.
+
+### Fixed
+
+- Pass Kokoro installer/exporter options by their long names through `Invoke-Uv`; PowerShell binds short flags like `-o` before uv runs.
+- `engine_status` for Kokoro checks for the duration-capable model, so the audio-only ONNX no longer counts as installed.
+
 ## [0.2.0] - 2026-09-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CopySpeak",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A simple and configurable AI-generated Text-to-Speech (TTS) orchestrator for Windows",
   "type": "module",
   "scripts": {

--- a/scripts/install-kokoro.ps1
+++ b/scripts/install-kokoro.ps1
@@ -5,8 +5,9 @@
 
 .DESCRIPTION
     Creates a uv-managed project under %LOCALAPPDATA%\CopySpeak\engines\kokoro,
-    installs kokoro-onnx, drops the stable CLI wrapper, and downloads the model
-    files (kokoro-v1.0.onnx + voices-v1.0.bin, ~335 MB) into <engine_dir>/models/.
+    installs kokoro-onnx and Misaki English, drops the CLI wrapper, and exports
+    a duration-capable ONNX model using the pinned upstream exporter. The first
+    installation also downloads the Kokoro checkpoint and export dependencies.
 
     The third-party `kokoro-tts` CLI this used to install reloaded the 310 MB
     model on every invocation and gave no way to pick an execution provider, so
@@ -83,8 +84,8 @@ Write-Host ""
 Write-Host "  [STEP] engine" -ForegroundColor Yellow
 $engineOk = $true
 try {
-    Write-Host "  Installing kokoro-onnx..." -ForegroundColor Gray
-    Invoke-Uv add --project $EngineDir "kokoro-onnx"
+    Write-Host "  Installing Kokoro and its English caption frontend..." -ForegroundColor Gray
+    Invoke-Uv add --project $EngineDir "kokoro-onnx==0.6.1" "misaki[en]==0.9.4" "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
 } catch {
     Write-Host "  [ERROR] engine (uv add failed: $_)" -ForegroundColor Red
     $engineOk = $false
@@ -105,16 +106,14 @@ if ($engineOk) { Write-Host "  [DONE] engine" -ForegroundColor Green }
 # Model files. kokoro-onnx requires these and does not auto-download them.
 # Stable home is <engine_dir>/models/ so the wrapper resolves them relative to
 # itself, the same way piper resolves its voices/.
-$modelFile = Join-Path $modelsDir "kokoro-v1.0.onnx"
+$modelFile = Join-Path $modelsDir "kokoro-v1.0-duration.onnx"
 $voicesFile = Join-Path $modelsDir "voices-v1.0.bin"
-$modelUrl = "https://github.com/nazdridoy/kokoro-tts/releases/download/v1.0.0/kokoro-v1.0.onnx"
 $voicesUrl = "https://github.com/nazdridoy/kokoro-tts/releases/download/v1.0.0/voices-v1.0.bin"
 
 if (-not $SkipModelDownload) {
     Write-Host "  [STEP] model" -ForegroundColor Yellow
     $modelOk = $true
     foreach ($f in @(
-        @{ Path = $modelFile;  Url = $modelUrl;  Label = "kokoro-v1.0.onnx (~310 MB, full quality)" },
         @{ Path = $voicesFile; Url = $voicesUrl; Label = "voices-v1.0.bin (~25 MB)" }
     )) {
         if (Test-Path $f.Path) {
@@ -131,6 +130,37 @@ if (-not $SkipModelDownload) {
             Remove-Item -Force -ErrorAction SilentlyContinue $f.Path
             Write-Host "  WARNING: download failed: $_" -ForegroundColor Red
             Write-Host "  Re-run with -Force, or download manually from $($f.Url)" -ForegroundColor Gray
+            $modelOk = $false
+        }
+    }
+    if ($engineOk -and -not (Test-Path $modelFile)) {
+        # Keep the old audio-only model intact. Promote the new artifact only
+        # after upstream's export and native-duration verification both succeed.
+        $exportDir = Join-Path $modelsDir "native-export"
+        New-Item -ItemType Directory -Force $exportDir | Out-Null
+        $exportScript = Join-Path $exportDir "export.py"
+        $exportConfig = Join-Path $exportDir "config.json"
+        $checkpoint = Join-Path $exportDir "kokoro-v1_0.pth"
+        $pendingModel = Join-Path $exportDir "kokoro-v1.0-duration.onnx"
+        $checkpointBase = "https://huggingface.co/hexgrad/Kokoro-82M/resolve/f3ff3571791e39611d31c381e3a41a3af07b4987"
+        try {
+            foreach ($source in @(
+                @{ Path = $exportScript; Url = "https://raw.githubusercontent.com/thewh1teagle/kokoro-onnx/3596b26764286a7de9d90c363e988d50578918e5/scripts/export.py" },
+                @{ Path = $exportConfig; Url = "$checkpointBase/config.json" },
+                @{ Path = $checkpoint; Url = "$checkpointBase/kokoro-v1_0.pth" }
+            )) {
+                if (-not (Test-Path $source.Path)) {
+                    $partial = $source.Path + ".download"
+                    Invoke-WebRequest -Uri $source.Url -OutFile $partial -UseBasicParsing
+                    Move-Item -LiteralPath $partial -Destination $source.Path -Force
+                }
+            }
+            # Kokoro's export package requires NumPy 1.x, which has no Python
+            # 3.13 wheel. Keep this build environment separate from inference.
+            Invoke-Uv run --no-project --python 3.12 --with "onnx==1.22.0" --with "onnxscript==0.7.2" --with "onnxruntime==1.29.0" --with "torch==2.14.0" --with "transformers==5.17.0" $exportScript --config $exportConfig --checkpoint $checkpoint --output $pendingModel
+            Move-Item -LiteralPath $pendingModel -Destination $modelFile
+        } catch {
+            Write-Host "  [ERROR] native caption model export: $_" -ForegroundColor Red
             $modelOk = $false
         }
     }

--- a/scripts/kokoro/copyspeak-kokoro.py
+++ b/scripts/kokoro/copyspeak-kokoro.py
@@ -22,6 +22,7 @@ install-kokoro.ps1.
 """
 
 import argparse
+import contextlib
 import glob
 import json
 import os
@@ -70,12 +71,12 @@ def read_text(args) -> str:
 
 
 def resolve_models(model_arg, voices_arg):
-    """Locate kokoro-v1.0.onnx and voices-v1.0.bin.
+    """Locate kokoro-v1.0-duration.onnx and voices-v1.0.bin.
 
     Wrapper lives in <engine_dir>/kokoro/scripts/; models in ../models/.
     """
     models_dir = Path(__file__).resolve().parent.parent / "models"
-    model = Path(model_arg) if model_arg else models_dir / "kokoro-v1.0.onnx"
+    model = Path(model_arg) if model_arg else models_dir / "kokoro-v1.0-duration.onnx"
     voices = Path(voices_arg) if voices_arg else models_dir / "voices-v1.0.bin"
     missing = [str(p) for p in (model, voices) if not p.exists()]
     if missing:
@@ -94,14 +95,86 @@ def pcm16(samples) -> bytes:
     return (clipped * 32767.0).astype("<i2").tobytes()
 
 
-def stream(kokoro, voice: str, text: str):
-    """Yield (pcm16_le_bytes, sample_rate, channels).
+def caption_batches(text, tokens, vocab):
+    """Keep source ownership while packing whole native tokens into ONNX windows."""
+    if "".join(t.text + t.whitespace for t in tokens) != text:
+        raise ValueError("Kokoro frontend did not preserve the original text")
+    phones, spans, offset = "", [], 0
+    for token in tokens:
+        if len(token.text.split()) > 1:
+            raise ValueError("Kokoro cannot caption merged words; replace tabs/unusual spaces with ordinary spaces")
+        ps = token.phonemes
+        if ps is None or any(p not in vocab for p in ps):
+            raise ValueError(f"Kokoro cannot map pronunciation to model tokens: {token.text!r}")
+        if len(ps) > 510:
+            raise ValueError("Kokoro source token exceeds the model window; shorten the word/expression")
+        if len(phones) + len(ps) > 510:
+            yield phones.rstrip(), spans
+            phones, spans = "", []
+        first = len(phones)
+        phones += ps
+        if any(p.isalpha() for p in ps):
+            # Keep numeric/emoji expansions as their native source token, never
+            # subdivide them by the number of words in their pronunciation.
+            left = offset + len(token.text) - len(token.text.lstrip())
+            right = offset + len(token.text.rstrip())
+            spans.append((len(text[:left].encode("utf-16-le")) // 2,
+                          len(text[:right].encode("utf-16-le")) // 2,
+                          first, len(phones)))
+        if token.whitespace and phones:
+            phones += " "
+        offset += len(token.text + token.whitespace)
+    if phones.strip():
+        yield phones.rstrip(), spans
 
-    kokoro-onnx also has an async create_stream(); create() is used here because
-    the daemon protocol is synchronous. Switching later needs no wire change.
+
+def native_words(text_spans, durations, sample_count, sample_offset):
+    """Native Kokoro frames are 600 samples at 24 kHz, including BOS/EOS."""
+    edges = [0]
+    for duration in durations:
+        if int(duration) != duration or duration <= 0:
+            raise ValueError("Kokoro returned invalid native durations")
+        edges.append(edges[-1] + int(duration) * 600)
+    if edges[-1] != sample_count:
+        raise ValueError("Kokoro duration geometry differs from its PCM; refusing to rescale")
+    return [{"text_start": start, "text_end": end,
+             "start_ms": (sample_offset + edges[first + 1]) / 24,
+             "end_ms": (sample_offset + edges[last + 1]) / 24}
+            for start, end, first, last in text_spans]
+
+
+def stream(kokoro, voice: str, text: str, frontend):
+    """Yield one complete alignment before a fragment's buffered PCM.
+
+    Bypass create_timed's rescaling/trimming/pause insertion. The raw inference
+    durations and waveform must come from the same call.
     """
-    samples, rate = kokoro.create(text, voice=voice)
-    yield pcm16(samples), rate, 1
+    import numpy as np
+
+    # Third-party frontend diagnostics must never enter the binary protocol.
+    with contextlib.redirect_stdout(sys.stderr):
+        _, tokens = frontend(text, preprocess=False)
+    vocab = kokoro.tokenizer.vocab
+    pcm, words, sample_offset = [], [], 0
+    # Validate the entire fragment before inference or releasing any PCM.
+    batches = list(caption_batches(text, tokens, vocab))
+    for phones, spans in batches:
+        ids = [vocab[p] for p in phones]
+        samples, durations = kokoro.sess.run(["waveform", "duration"], {
+            "input_ids": np.array([[0, *ids, 0]], dtype=np.int64),
+            "style": kokoro.get_voice_style(voice)[len(ids) - 1].reshape(1, 256).astype(np.float32),
+            # Playback speed/pitch belong to CopySpeak's TimeStretcher.
+            "speed": np.array([1.0], dtype=np.float32),
+        })
+        samples, durations = samples.reshape(-1), durations.reshape(-1)
+        if len(durations) != len(ids) + 2 or not np.isfinite(samples).all():
+            raise ValueError("Kokoro native alignment does not match the generated audio")
+        words.extend(native_words(spans, durations, len(samples), sample_offset))
+        pcm.append(pcm16(samples))
+        sample_offset += len(samples)
+    if not pcm:
+        raise ValueError("Kokoro produced no pronunciation for this text")
+    yield b"".join(pcm), 24000, 1, {"text": text, "words": words}
 
 
 def write_wav(output: str, pcm: bytes, rate: int, channels: int) -> None:
@@ -113,7 +186,7 @@ def write_wav(output: str, pcm: bytes, rate: int, channels: int) -> None:
         wf.writeframes(pcm)
 
 
-def serve(kokoro, voice: str) -> int:
+def serve(kokoro, voice: str, frontend) -> int:
     """Daemon mode, protocol v2. Model stays resident; PCM is framed on stdout.
 
     Everything goes through sys.stdout.buffer — mixing text and binary writes to
@@ -132,7 +205,7 @@ def serve(kokoro, voice: str) -> int:
     # Best effort: a warmup failure is not a reason to refuse to serve, and the
     # real request will surface the same error properly framed.
     try:
-        for _ in stream(kokoro, voice, "Ready."):
+        for _ in stream(kokoro, voice, "Ready.", frontend):
             pass
     except Exception as exc:  # pragma: no cover - environment dependent
         print(f"WARNING: warmup failed: {exc}", file=sys.stderr, flush=True)
@@ -148,24 +221,16 @@ def serve(kokoro, voice: str) -> int:
         if not line:
             continue
         try:
-            chunks = stream(kokoro, voice, json.loads(line)["text"])
-            first = next(chunks, None)
-            if first is None:
-                raise RuntimeError("no audio produced")
-            pcm, rate, channels = first
+            pcm, rate, channels, captions = next(stream(kokoro, voice, json.loads(line)["text"], frontend))
             frame({
                 "ok": True,
                 "sample_rate": rate,
                 "channels": channels,
                 "bits_per_sample": 16,
             })
-            while True:
-                frame({"chunk": len(pcm)})
-                out.write(pcm)
-                nxt = next(chunks, None)
-                if nxt is None:
-                    break
-                pcm = nxt[0]
+            frame({"captions": captions})
+            frame({"chunk": len(pcm)})
+            out.write(pcm)
             frame({"end": True})
         except Exception as exc:  # pragma: no cover - environment dependent
             frame({"ok": False, "error": str(exc)})
@@ -177,7 +242,7 @@ def main() -> int:
     parser.add_argument("--text", help="Inline text to synthesize")
     parser.add_argument("--text-file", help="Path to a UTF-8 text file to synthesize")
     parser.add_argument("--voice", default="af_heart", help="Kokoro voice id (e.g. af_heart)")
-    parser.add_argument("--model", help="Path to kokoro-v1.0.onnx (default: ../models/)")
+    parser.add_argument("--model", help="Path to duration-capable Kokoro ONNX (default: ../models/kokoro-v1.0-duration.onnx)")
     parser.add_argument("--voices", help="Path to voices-v1.0.bin (default: ../models/)")
     parser.add_argument("--output", help="Output WAV file path (required unless --serve)")
     parser.add_argument("--serve", action="store_true", help="Keep the model in RAM and read JSON requests on stdin")
@@ -214,6 +279,14 @@ def main() -> int:
 
     try:
         kokoro = Kokoro(model_path, voices_path)
+        if not {"waveform", "duration"}.issubset(o.name for o in kokoro.sess.get_outputs()):
+            raise ValueError("Kokoro needs the duration-capable model; re-run install-kokoro.ps1")
+        if args.voice[:1] not in ("a", "b"):
+            raise ValueError("Kokoro native source captions currently support English voices only")
+        with contextlib.redirect_stdout(sys.stderr):
+            from misaki import en, espeak
+            british = args.voice.startswith("b")
+            frontend = en.G2P(trf=False, british=british, fallback=espeak.EspeakFallback(british=british))
     except Exception as exc:  # pragma: no cover - environment dependent
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
@@ -222,11 +295,12 @@ def main() -> int:
     print(f"providers: {kokoro.sess.get_providers()}", file=sys.stderr, flush=True)
 
     if args.serve:
-        return serve(kokoro, args.voice)
+        return serve(kokoro, args.voice, frontend)
 
     try:
-        pcm, rate, channels = next(stream(kokoro, args.voice, text))
+        pcm, rate, channels, captions = next(stream(kokoro, args.voice, text, frontend))
         write_wav(args.output, pcm, rate, channels)
+        Path(args.output + ".captions.json").write_text(json.dumps(captions), encoding="utf-8")
         print(f"OK -> {args.output}", file=sys.stderr)
         return 0
     except Exception as exc:  # pragma: no cover - environment dependent

--- a/scripts/test-caption-alignment.py
+++ b/scripts/test-caption-alignment.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 
 def load(relative):
@@ -16,9 +17,63 @@ def load(relative):
 
 piper = load("piper/copyspeak-piper.py")
 edge = load("edge/copyspeak-edge.py")
+kokoro = load("kokoro/copyspeak-kokoro.py")
 
 
 class AlignmentTests(unittest.TestCase):
+    def test_kokoro_native_frames_keep_bos_spaces_punctuation_and_utf16(self):
+        tokens = [SimpleNamespace(text=t, whitespace=w, phonemes=p) for t, w, p in
+                  [("😀", " ", "a"), ("Hi", "", "hi"), (",", " ", ","), ("there", "", "b")]]
+        phones, spans = next(kokoro.caption_batches("😀 Hi, there", tokens, dict.fromkeys("ahi,b ", 1)))
+        self.assertEqual(phones, "a hi, b")
+        words = kokoro.native_words(spans, [2, 1, 3, 4, 2, 5, 6, 7, 8], 22800, 2400)
+        self.assertEqual(words, [
+            {"text_start": 0, "text_end": 2, "start_ms": 150, "end_ms": 175},
+            {"text_start": 3, "text_end": 5, "start_ms": 250, "end_ms": 400},
+            {"text_start": 7, "text_end": 12, "start_ms": 675, "end_ms": 850},
+        ])
+        with self.assertRaisesRegex(ValueError, "refusing to rescale"):
+            kokoro.native_words(spans, [2, 1, 3, 4, 2, 5, 6, 7, 8], 22799, 0)
+
+    def test_kokoro_rejects_ambiguous_source_and_unknown_model_symbols(self):
+        token = SimpleNamespace(text="do\tnot", whitespace="", phonemes="du nat")
+        with self.assertRaisesRegex(ValueError, "merged words"):
+            list(kokoro.caption_batches(token.text, [token], dict.fromkeys(token.phonemes)))
+        token = SimpleNamespace(text="Hi", whitespace="", phonemes="h?")
+        with self.assertRaisesRegex(ValueError, "model tokens"):
+            list(kokoro.caption_batches("Hi", [token], {"h": 1}))
+        with self.assertRaisesRegex(ValueError, "original text"):
+            list(kokoro.caption_batches("Hi!", [token], {"h": 1}))
+
+    def test_kokoro_whole_token_chunks_keep_source_offsets(self):
+        tokens = [SimpleNamespace(text=t, whitespace=w, phonemes=p) for t, w, p in
+                  [("first", " ", "a" * 509), ("next", "", "b")]]
+        batches = list(kokoro.caption_batches("first next", tokens, {"a": 1, "b": 2, " ": 3}))
+        self.assertEqual([len(phones) for phones, _ in batches], [509, 1])
+        self.assertEqual(batches[1][1], [(6, 10, 0, 1)])
+        # Offset includes the first chunk's EOS/trailing silence, not last word end.
+        words = kokoro.native_words(batches[1][1], [2, 3, 4], 5400, 306600)
+        self.assertEqual(words[0]["start_ms"], 12825)
+
+    def test_kokoro_sends_one_complete_caption_frame_before_pcm(self):
+        captions = {"text": "Hi", "words": [{"text_start": 0, "text_end": 2,
+                    "start_ms": 25, "end_ms": 50}]}
+        pcm = b"\x01\x00\x02\x00"
+        output = SimpleNamespace(buffer=io.BytesIO())
+        def stream(*args):
+            yield pcm, 24000, 1, captions
+        with patch.object(kokoro, "stream", stream), patch.object(kokoro.sys, "stdout", output), \
+                patch.object(kokoro.sys, "stdin", io.StringIO('{"text":"Hi"}\n')):
+            self.assertEqual(kokoro.serve(None, "af_heart", None), 0)
+        wire = io.BytesIO(output.buffer.getvalue())
+        self.assertEqual(wire.readline(), b"READY 2\n")
+        self.assertEqual(json.loads(wire.readline())["bits_per_sample"], 16)
+        self.assertEqual(json.loads(wire.readline()), {"captions": captions})
+        self.assertEqual(json.loads(wire.readline()), {"chunk": len(pcm)})
+        self.assertEqual(wire.read(len(pcm)), pcm)
+        self.assertEqual(json.loads(wire.readline()), {"end": True})
+        self.assertEqual(wire.read(), b"")
+
     def test_native_sample_counts_preserve_silence_and_sentence_offsets(self):
         alignment = [SimpleNamespace(phoneme=p, num_samples=n) for p, n in
                      [("^", 100), ("h", 40), ("i", 60), (",", 250), (" ", 50), ("b", 70), ("$", 100)]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copyspeak"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "CopySpeak - AI text-to-speech orchestrator"
 

--- a/src-tauri/src/commands/install.rs
+++ b/src-tauri/src/commands/install.rs
@@ -386,11 +386,12 @@ pub fn engine_status(engine: String) -> Result<EngineStatus, String> {
             .map(|d| d.join("manifest.json").exists() && d.join("pyproject.toml").exists())
             .unwrap_or(false),
         // Kokoro refuses to synthesize without these two model files, which the
-        // installer downloads separately from the package.
+        // installer prepares separately from the package. The old audio-only
+        // ONNX does not satisfy the native-caption wrapper's requirements.
         "kokoro" => engine_dir("kokoro")
             .map(|d| {
                 d.join("manifest.json").exists()
-                    && d.join("models").join("kokoro-v1.0.onnx").exists()
+                    && d.join("models").join("kokoro-v1.0-duration.onnx").exists()
                     && d.join("models").join("voices-v1.0.bin").exists()
             })
             .unwrap_or(false),

--- a/src-tauri/src/tts/catalog.rs
+++ b/src-tauri/src/tts/catalog.rs
@@ -188,11 +188,11 @@ pub fn list_engines() -> Vec<EngineCatalogEntry> {
         EngineCatalogEntry {
             engine: TtsEngine::Kokoro,
             label: "Kokoro".into(),
-            description: "Free local TTS via Kokoro — one shared model, curated voice set.".into(),
+            description: "Free local TTS via Kokoro, with native English captions after reinstalling the duration-capable model.".into(),
             docs_url: "https://github.com/thewh1teagle/kokoro-onnx".into(),
             supports_voice_refresh: false,
             supports_pitch: false,
-            supports_captions: false,
+            supports_captions: true,
             supports_bracket_emotes: false,
             options: vec![option(
                 "cuda",
@@ -1176,6 +1176,7 @@ mod tests {
             supported,
             [
                 TtsEngine::Piper,
+                TtsEngine::Kokoro,
                 TtsEngine::ElevenLabs,
                 TtsEngine::Cartesia,
                 TtsEngine::Edge,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "CopySpeak",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.copyspeak.tts",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/engine/profile-manager.svelte
+++ b/src/lib/components/engine/profile-manager.svelte
@@ -197,7 +197,7 @@
     catalog.length
       ? catalog.map((entry) => ({
           value: entry.engine,
-          label: entry.supports_captions ? entry.label : `${entry.label} (no live captions)`
+          label: entry.label
         }))
       : fallbackEngineOptions
   );


### PR DESCRIPTION
## Summary
- Kokoro exports and uses a duration-capable ONNX model (`kokoro-v1.0-duration.onnx`) built with the pinned upstream exporter under isolated Python 3.12; catalog now reports `supports_captions: true`.
- Installer adds `misaki[en]` caption frontend and downloads/export the model with long-name options (avoids PowerShell flag binding).
- `engine_status` requires the duration model; profile manager no longer suffixes labels with "(no live captions)".
- Adds `scripts/test-caption-alignment.py`; AGENTS.md failure-log entries.
- Changelog entry for 0.2.1, version bump to 0.2.1.