### PR TITLE
fix(browser): per-word source alignment and resilient Kokoro phonemes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,9 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 - Register CUDA DLL directories with `os.add_dll_directory` inside the wrapper; Python 3.8+ ignores `PATH` for extension-module dependencies, so setting it from Rust does nothing.
 - Emit the streaming `is_final` marker on the last fragment only; an intermediate one arms the player's completion timer mid-passage.
 - KittenTTS 0.8.1 (the pinned wheel) takes only `KittenTTS(model_name, cache_dir)`; select the GPU by replacing `tts.model.session`, not with a `backend=` kwarg that only exists on `main`.
+- Map browser caption words onto the raw selection with `text_map::align`'s word alignment; never re-derive the sanitizer's rewrites in a second place, and keep the highlight verdict per word and per fragment rather than per reading.
 - Pass `uv init` its target directory positionally (`uv init --bare --name X <dir>`); uv 0.12+ hard-errors on `uv --project <dir> init`, which only shows up when creating a fresh engine project.
+- Filter Kokoro's misaki phonemes through the model vocab before inference; misaki emits unpronounceable punctuation (an unbalanced `[`) as a literal phoneme, and only a missing *letter* phoneme is a real pronunciation gap worth aborting on.
 
 <!-- rtk-instructions v2 -->
 

--- a/BROWSER_EXTENSION.md
+++ b/BROWSER_EXTENSION.md
@@ -24,10 +24,12 @@ support are rejected.
 `\\.\pipe\copyspeak-browser`. The desktop bridge starts a normal CopySpeak
 reading and projects audible caption timings back to the original selection.
 
-Word highlighting is deliberately conservative: it is enabled only when the
-sanitized text, paginated fragments, and caption text can be mapped exactly to
-the original selection. Otherwise the passage remains highlighted without a
-current-word marker.
+Word highlighting degrades per word and per fragment, never per reading. The
+raw selection and the sanitized text are aligned word by word, so a word the
+sanitizer rewrote maps to the source run it replaced and a word it invented
+(`%` → "percent") maps to the punctuation it expanded. A fragment whose engine
+sent no usable caption timings keeps the passage highlighted without a
+current-word marker, while the fragments around it still follow the word.
 
 ## Developer setup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Browser companion word highlighting now survives sanitization** — the source map used to *replay* a hand-picked subset of the sanitizer's rewrites and reject everything else, so a single `%` expanding to " percent" switched word highlighting off for a whole reading. `text_map` now aligns the raw selection and the spoken text word by word (order-preserving, with bounded resynchronization), so only a word the sanitizer invented loses its highlight — and it points at the punctuation it came from.
+- **Live-caption verdicts are per fragment, not per reading** — the browser panel no longer reports "Word highlighting unavailable" for an entire reading while later fragments are still being synthesized, and a synthesis event belonging to a different reading is ignored instead of degrading the browser session.
+- **Kokoro no longer aborts a reading on an unpronounceable bracket** — misaki passes punctuation it cannot pronounce straight through as a phoneme (an unbalanced `[` from a link-heavy web selection, a guillemet). Those symbols are absent from Kokoro's vocab and carry no sound, so the wrapper drops them instead of failing the fragment with `Kokoro cannot map pronunciation to model tokens: '[02:11'`. A missing *letter* phoneme is still a hard error.
+
 ## [0.2.1] - 2026-09-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CopySpeak
 
-**Current Version:** 0.2.0
+**Current Version:** 0.2.1
 
 A modern Windows desktop app that reads clipboard text aloud using AI Text-to-Speech engines. Trigger speech by quickly copying the same text twice in a row.
 

--- a/scripts/kokoro/copyspeak-kokoro.py
+++ b/scripts/kokoro/copyspeak-kokoro.py
@@ -104,8 +104,13 @@ def caption_batches(text, tokens, vocab):
         if len(token.text.split()) > 1:
             raise ValueError("Kokoro cannot caption merged words; replace tabs/unusual spaces with ordinary spaces")
         ps = token.phonemes
-        if ps is None or any(p not in vocab for p in ps):
+        if ps is None or any(p.isalpha() and p not in vocab for p in ps):
             raise ValueError(f"Kokoro cannot map pronunciation to model tokens: {token.text!r}")
+        # misaki passes punctuation it cannot pronounce straight through as a
+        # phoneme (an unbalanced "[", a guillemet). Those carry no sound and are
+        # absent from Kokoro's vocab, so drop them rather than abort the reading.
+        # A missing *letter* phoneme is a real pronunciation gap - stay loud.
+        ps = "".join(p for p in ps if p in vocab)
         if len(ps) > 510:
             raise ValueError("Kokoro source token exceeds the model window; shorten the word/expression")
         if len(phones) + len(ps) > 510:

--- a/scripts/test-caption-alignment.py
+++ b/scripts/test-caption-alignment.py
@@ -39,11 +39,20 @@ class AlignmentTests(unittest.TestCase):
         token = SimpleNamespace(text="do\tnot", whitespace="", phonemes="du nat")
         with self.assertRaisesRegex(ValueError, "merged words"):
             list(kokoro.caption_batches(token.text, [token], dict.fromkeys(token.phonemes)))
-        token = SimpleNamespace(text="Hi", whitespace="", phonemes="h?")
+        token = SimpleNamespace(text="Hi", whitespace="", phonemes="hz")
         with self.assertRaisesRegex(ValueError, "model tokens"):
             list(kokoro.caption_batches("Hi", [token], {"h": 1}))
         with self.assertRaisesRegex(ValueError, "original text"):
             list(kokoro.caption_batches("Hi!", [token], {"h": 1}))
+
+    def test_kokoro_drops_unpronounceable_punctuation_instead_of_aborting(self):
+        # misaki leaks an unbalanced "[" into the phonemes of "[02:11"; it is not
+        # in Kokoro's vocab and must not kill the reading.
+        tokens = [SimpleNamespace(text=t, whitespace=w, phonemes=p) for t, w, p in
+                  [("at", " ", "at"), ("[02:11", "", "[tu:"), ("]", "", ")")]]
+        phones, spans = next(kokoro.caption_batches("at [02:11]", tokens, dict.fromkeys("atu: ", 1)))
+        self.assertEqual(phones, "at tu:")
+        self.assertEqual(spans, [(0, 2, 0, 2), (3, 9, 3, 6)])
 
     def test_kokoro_whole_token_chunks_keep_source_offsets(self):
         tokens = [SimpleNamespace(text=t, whitespace=w, phonemes=p) for t, w, p in

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -3,13 +3,18 @@
 //
 // Word-highlight pipeline (all exact, no fuzzy matching):
 //   raw selection (extension UTF-16 space)
-//     → sanitize_text → spoken text          [WhitespaceMap, or passage-only]
+//     → sanitize_text → spoken text          [TextAlignment: raw ↔ spoken words]
 //     → paginate_text → fragment table        [per-fragment UTF-16 spans]
 //     → synthesis events carry per-fragment CaptionAlignment (fragment-local)
 //     → frontend reports (fragment_index, position_ms) from the audible clock
 //   word = captions word at position → fragment-local UTF-16
 //        → + fragment.text_start = spoken-page UTF-16
-//        → WhitespaceMap.source_span_utf16 = raw UTF-16 sent to the extension.
+//        → TextAlignment.source_span_utf16 = raw UTF-16 sent to the extension.
+//
+// Degradation is per word and per fragment, never per reading: a word the
+// sanitizer invented simply has no source span, and a fragment whose engine
+// sent no usable captions falls back to passage-only while the rest of the
+// reading keeps highlighting.
 
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -25,7 +30,7 @@ use windows::Win32::System::Threading::{CreateEventW, WaitForSingleObject, INFIN
 use windows::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
 
 use crate::sanitize::tts_normalize::punct_equivalent;
-use crate::text_map::{whitespace_map, WhitespaceMap};
+use crate::text_map::{align, TextAlignment};
 use crate::tts::captions::{CaptionAlignment, WordTiming};
 
 const PIPE_NAME: &str = r"\\.\pipe\copyspeak-browser";
@@ -93,28 +98,14 @@ struct FragmentEntry {
     captions_ok: bool,
 }
 
-/// Fragment table + mapping state for one browser reading.
-#[derive(Default)]
-struct FragmentTable {
-    fragments: Vec<FragmentEntry>,
-    /// False once any fragment deviated from the expected tile (e.g. LLM
-    /// post-processing rewrote the text): degrade to passage-only.
-    tiling_ok: bool,
-    /// False once any fragment's captions were missing or mismatched its text.
-    captions_ok: bool,
-}
-
 struct BrowserSession {
     reading_id: String,
     sequence: AtomicU64,
-    /// Selected (raw) text, the extension's UTF-16 space.
-    raw_text: String,
     /// Sanitized text CopySpeak actually speaks.
     spoken_text: String,
-    /// Raw→spoken exact map; `None` means sanitization was not a pure
-    /// whitespace collapse and word highlighting degrades to passage-only.
-    source_map: Option<WhitespaceMap>,
-    table: Mutex<FragmentTable>,
+    /// Raw ↔ spoken word alignment; always present.
+    source_map: TextAlignment,
+    fragments: Mutex<Vec<FragmentEntry>>,
     active_fragment: AtomicUsize,
     /// Audible-clock position inside the active fragment (ms).
     position_ms: AtomicU64,
@@ -327,8 +318,8 @@ fn record_fragment_captions(
     };
     drop(sessions);
 
-    let mut table = session.table.lock().unwrap();
-    apply_fragment_event(&mut table, index, text, captions);
+    let mut fragments = session.fragments.lock().unwrap();
+    apply_fragment_event(&mut fragments, index, text, captions);
 }
 
 /// Core caption/tile bookkeeping for one synthesis event, as it maps onto the
@@ -339,45 +330,31 @@ fn record_fragment_captions(
 /// - caption item: `text=None`, `captions=Some` (ElevenLabs emits captions as
 ///   a standalone stream item, never paired with chunk text)
 fn apply_fragment_event(
-    table: &mut FragmentTable,
+    fragments: &mut [FragmentEntry],
     index: usize,
     text: Option<&str>,
     captions: Option<CaptionAlignment>,
 ) {
-    let Some(entry) = table.fragments.get_mut(index) else {
+    let Some(entry) = fragments.get_mut(index) else {
         return;
     };
     // Caption-only chunk events arrive with `text: None`, so only verify the
-    // tile when an event actually carries text.
-    if let Some(text) = text {
-        if entry.expected_text != text {
-            // A desktop reading (or post-processing rewrite) invaded the event
-            // stream: exact tiling is gone, degrade to passage-only.
-            table.tiling_ok = false;
-            return;
-        }
+    // tile when an event actually carries text. An event whose text is not
+    // this tile describes someone else's reading (or a post-processing
+    // rewrite): ignore it, rather than degrading a session it never named.
+    if text.is_some_and(|text| text != entry.expected_text) {
+        return;
     }
-    if let Some(caps) = captions {
-        match rebased_captions(caps, &entry.expected_text) {
-            Some(rebased) if rebased.validate().is_ok() => {
-                entry.captions = Some(rebased);
-                entry.captions_ok = true;
-            }
-            _ => {
-                entry.captions_ok = false;
-            }
+    let Some(caps) = captions else {
+        return;
+    };
+    match rebased_captions(caps, &entry.expected_text) {
+        Some(rebased) if rebased.validate().is_ok() => {
+            entry.captions = Some(rebased);
+            entry.captions_ok = true;
         }
-    } else if entry.captions.is_none() {
-        // A text chunk arrived before its captions: pessimistically flag the
-        // fragment. Recoverable — captions_ok is re-derived below once
-        // captions land, so this no longer wedges the whole table.
-        entry.captions_ok = false;
+        _ => entry.captions_ok = false,
     }
-    // The table-level caption verdict is derived from the per-fragment state
-    // on every event. A sticky `false` set by an early captionless chunk used
-    // to survive the later caption arrival, keeping `word_available` false for
-    // the whole reading (2026-09-09).
-    table.captions_ok = table.fragments.iter().all(|f| f.captions_ok);
 }
 
 /// Rebase caption word offsets from `caps.text` into `expected`'s coordinate
@@ -649,16 +626,7 @@ fn start_browser_reading(
         send_rejected(pipe, &request_id, "Text is empty after sanitization")?;
         return Ok(());
     }
-    let source_map = whitespace_map(&raw_text, &spoken_text);
-    if source_map.is_none() {
-        // False-degrade triage: log how the sanitized text diverged from the
-        // raw selection's whitespace collapse + canonical same-length fold.
-        log::warn!(
-            "[Browser] Word highlighting unavailable: {}",
-            crate::text_map::first_divergence(&raw_text, &spoken_text)
-                .unwrap_or_else(|| "map rejected despite matching gate inputs (bug)".to_string())
-        );
-    }
+    let source_map = align(&raw_text, &spoken_text);
 
     // Pre-paginate with the same config speak_queued will use, so synthesis
     // events can be verified tile-by-tile against this table.
@@ -679,21 +647,14 @@ fn start_browser_reading(
             captions_ok: false,
         });
     }
-    let tiling = FragmentTable {
-        fragments,
-        tiling_ok: source_map.is_some(),
-        captions_ok: true,
-    };
-
     let reading_id = format!("browser-{}", request_id);
 
     let session = Arc::new(BrowserSession {
         reading_id: reading_id.clone(),
         sequence: AtomicU64::new(0),
-        raw_text,
         spoken_text,
         source_map,
-        table: Mutex::new(tiling),
+        fragments: Mutex::new(fragments),
         active_fragment: AtomicUsize::new(NO_FRAGMENT),
         position_ms: AtomicU64::new(0),
         status: AtomicU8::new(SessionStatus::Buffering as u8),
@@ -885,23 +846,24 @@ fn spawn_state_ticker(app: AppHandle, session: Arc<BrowserSession>) {
     });
 }
 
-/// Why word highlighting degrades to passage-only for a session, in pipeline
-/// order: sanitization that is not a pure whitespace collapse, a synthesis
-/// event whose text deviated from the expected tile, or captions that are
-/// missing/mismatched after rebase. `None` = word highlighting available.
-/// Single source for the `word_available` verdict and its diagnosis.
+/// Why word highlighting degrades to passage-only, judged for the fragment
+/// that is currently audible: its engine sent no captions, or captions that
+/// did not match the fragment's own text. `None` = word highlighting
+/// available. Single source for the `word_available` verdict.
+///
+/// The verdict is per fragment, not per reading: one caption-less fragment
+/// must not switch highlighting off for the fragments around it.
 fn degrade_reason(session: &BrowserSession) -> Option<&'static str> {
-    if session.source_map.is_none() {
-        return Some("unmappable_sanitization");
+    let index = session.active_fragment.load(Ordering::Relaxed);
+    if index == NO_FRAGMENT {
+        // Nothing audible yet — no verdict to report.
+        return None;
     }
-    let table = session.table.lock().unwrap();
-    if !table.tiling_ok {
-        return Some("tiling_diverged");
+    let fragments = session.fragments.lock().unwrap();
+    match fragments.get(index) {
+        Some(entry) if entry.captions_ok => None,
+        _ => Some("captions_unavailable"),
     }
-    if !table.captions_ok {
-        return Some("captions_unavailable");
-    }
-    None
 }
 
 /// Current (status, word-in-raw-space, degrade-reason) for a session.
@@ -917,18 +879,17 @@ fn project_state(
     (status, word, reason)
 }
 
-/// Exact projection of the audible word into the raw selection's UTF-16 space.
+/// Projection of the audible word into the raw selection's UTF-16 space.
 fn current_word(session: &BrowserSession) -> Option<(usize, usize)> {
-    if degrade_reason(session).is_some() {
-        return None;
-    }
-    let map = session.source_map.as_ref()?;
-    let table = session.table.lock().unwrap();
     let fragment_index = session.active_fragment.load(Ordering::Relaxed);
     if fragment_index == NO_FRAGMENT {
         return None;
     }
-    let entry = table.fragments.get(fragment_index)?;
+    let fragments = session.fragments.lock().unwrap();
+    let entry = fragments.get(fragment_index)?;
+    if !entry.captions_ok {
+        return None;
+    }
     let captions = entry.captions.as_ref()?;
     let position_ms = session.position_ms.load(Ordering::Relaxed) as f64;
     let (local_start, local_end) = find_word_at_position(&captions.words, position_ms)?;
@@ -938,7 +899,7 @@ fn current_word(session: &BrowserSession) -> Option<(usize, usize)> {
     if page_end > entry.text_end {
         return None;
     }
-    map.source_span_utf16(&session.raw_text, page_start, page_end)
+    session.source_map.source_span_utf16(page_start, page_end)
 }
 
 fn send_accepted(pipe: &SafeHandle, request_id: &str, reading_id: &str) -> Result<(), String> {
@@ -1033,6 +994,25 @@ mod tests {
     use super::*;
     use crate::tts::captions::WordTiming;
 
+    fn word(text_start: usize, text_end: usize) -> WordTiming {
+        WordTiming {
+            text_start,
+            text_end,
+            start_ms: 0.0,
+            end_ms: 100.0,
+        }
+    }
+
+    fn entry(text: &str, text_start: usize, text_end: usize) -> FragmentEntry {
+        FragmentEntry {
+            text_start,
+            text_end,
+            expected_text: text.to_string(),
+            captions: None,
+            captions_ok: false,
+        }
+    }
+
     fn session_with(
         raw: &str,
         spoken: &str,
@@ -1042,28 +1022,17 @@ mod tests {
         let entries: Vec<FragmentEntry> = fragments
             .into_iter()
             .map(|(text, start, end)| FragmentEntry {
-                text_start: start,
-                text_end: end,
-                expected_text: text.to_string(),
-                captions: if captions.is_some() && end - start > 0 {
-                    captions.clone()
-                } else {
-                    None
-                },
+                captions: captions.clone(),
                 captions_ok: captions.is_some(),
+                ..entry(text, start, end)
             })
             .collect();
         BrowserSession {
             reading_id: "r".into(),
             sequence: AtomicU64::new(0),
-            raw_text: raw.to_string(),
             spoken_text: spoken.to_string(),
-            source_map: whitespace_map(raw, spoken),
-            table: Mutex::new(FragmentTable {
-                fragments: entries,
-                tiling_ok: true,
-                captions_ok: true,
-            }),
+            source_map: align(raw, spoken),
+            fragments: Mutex::new(entries),
             active_fragment: AtomicUsize::new(0),
             position_ms: AtomicU64::new(0),
             status: AtomicU8::new(SessionStatus::Playing as u8),
@@ -1072,19 +1041,14 @@ mod tests {
     }
 
     #[test]
-    fn word_projects_through_fragment_and_whitespace_map() {
+    fn word_projects_through_fragment_and_source_alignment() {
         let raw = "Hello world.\n\nSecond sentence";
         let spoken = "Hello world. Second sentence";
         // One fragment covering all of spoken; caption word "Second" at
         // fragment-local 13..19 (UTF-16), i.e. spoken-page 13..19.
         let captions = CaptionAlignment {
             text: spoken.to_string(),
-            words: vec![WordTiming {
-                text_start: 13,
-                text_end: 19,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(13, 19)],
         };
         let session = session_with(
             raw,
@@ -1093,7 +1057,7 @@ mod tests {
             Some(captions),
         );
         let (s, e) = current_word(&session).unwrap();
-        assert_eq!(&session.raw_text[s..e], "Second");
+        assert_eq!(&raw[s..e], "Second");
     }
 
     #[test]
@@ -1102,12 +1066,7 @@ mod tests {
         let spoken = "buffalo buffalo buffalo";
         let captions = CaptionAlignment {
             text: spoken.to_string(),
-            words: vec![WordTiming {
-                text_start: 16,
-                text_end: 23,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(16, 23)],
         };
         let session = session_with(
             raw,
@@ -1117,52 +1076,82 @@ mod tests {
         );
         let (s, e) = current_word(&session).unwrap();
         assert_eq!(s, 16);
-        assert_eq!(&session.raw_text[s..e], "buffalo");
+        assert_eq!(&raw[s..e], "buffalo");
     }
 
+    /// Regression for the 2026-09-10 live failure: one `%` in the selection
+    /// expanded to " percent" during sanitization, and the old exact-replay
+    /// map rejected the whole reading. Highlighting must survive it.
     #[test]
-    fn unmappable_sanitization_degrades_to_passage_only() {
-        // Sanitization rewrote text: no whitespace map exists.
-        let session = session_with("see https://x.com now", "see link now", vec![], None);
-        assert!(session.source_map.is_none());
-        let (_, word, reason) = project_state(&session);
-        assert!(word.is_none());
-        assert_eq!(reason, Some("unmappable_sanitization"));
-    }
-
-    /// Degrade reasons report the FIRST failed gate, in pipeline order.
-    #[test]
-    fn degrade_reasons_report_in_pipeline_order() {
-        let session = session_with("see https://x.com now", "see link now", vec![], None);
-        session.table.lock().unwrap().tiling_ok = false;
-        assert_eq!(
-            degrade_reason(&session),
-            Some("unmappable_sanitization"),
-            "map gate precedes tiling gate"
-        );
-        // With a map present, tiling divergence outranks captions.
+    fn sanitizer_expansion_keeps_the_reading_highlighting() {
+        let raw = "Around 10-20% of measles cases result in hospitalization.";
+        let spoken =
+            crate::sanitize::sanitize_text(raw, &crate::config::SanitizationConfig::default());
+        let start = spoken.find("measles").unwrap();
+        let captions = CaptionAlignment {
+            text: spoken.clone(),
+            words: vec![word(start, start + "measles".len())],
+        };
         let session = session_with(
-            "plain text",
-            "plain text",
-            vec![("plain text", 0, 10)],
-            None,
+            raw,
+            &spoken,
+            vec![(spoken.as_str(), 0, spoken.encode_utf16().count())],
+            Some(captions),
         );
-        {
-            let mut table = session.table.lock().unwrap();
-            table.tiling_ok = false;
-            table.captions_ok = false;
-        }
-        assert_eq!(degrade_reason(&session), Some("tiling_diverged"));
+        let (_, projected, reason) = project_state(&session);
+        assert_eq!(reason, None, "expansion must not degrade the reading");
+        let (s, e) = projected.unwrap();
+        assert_eq!(&raw[s..e], "measles");
     }
 
     #[test]
     fn missing_captions_report_captions_unavailable() {
         let spoken = "plain text";
         let session = session_with(spoken, spoken, vec![(spoken, 0, 10)], None);
-        session.table.lock().unwrap().captions_ok = false;
-        let (_, word, reason) = project_state(&session);
-        assert!(word.is_none());
+        let (_, projected, reason) = project_state(&session);
+        assert!(projected.is_none());
         assert_eq!(reason, Some("captions_unavailable"));
+    }
+
+    /// The caption verdict is per fragment: a fragment whose engine sent no
+    /// captions must not switch highlighting off for the one being read.
+    #[test]
+    fn caption_verdict_follows_the_audible_fragment() {
+        let spoken = "first tile second tile";
+        let second = "second tile";
+        let start = spoken.find(second).unwrap();
+        let captions = CaptionAlignment {
+            text: second.to_string(),
+            words: vec![word(0, 6)],
+        };
+        let session = session_with(
+            spoken,
+            spoken,
+            vec![("first tile", 0, 10), (second, start, start + second.len())],
+            None,
+        );
+        {
+            let mut fragments = session.fragments.lock().unwrap();
+            fragments[1].captions = Some(captions);
+            fragments[1].captions_ok = true;
+        }
+        assert_eq!(degrade_reason(&session), Some("captions_unavailable"));
+        session.active_fragment.store(1, Ordering::Relaxed);
+        assert_eq!(degrade_reason(&session), None);
+        let (s, e) = current_word(&session).unwrap();
+        assert_eq!(&spoken[s..e], "second");
+    }
+
+    /// Nothing is audible yet during buffering, so there is no verdict to
+    /// report and the panel must not claim highlighting is unavailable.
+    #[test]
+    fn buffering_session_reports_no_degrade_reason() {
+        let spoken = "plain text";
+        let session = session_with(spoken, spoken, vec![(spoken, 0, 10)], None);
+        session.active_fragment.store(NO_FRAGMENT, Ordering::Relaxed);
+        let (_, projected, reason) = project_state(&session);
+        assert!(projected.is_none());
+        assert_eq!(reason, None);
     }
 
     #[test]
@@ -1170,12 +1159,7 @@ mod tests {
         let spoken = "plain text";
         let caps = CaptionAlignment {
             text: spoken.to_string(),
-            words: vec![WordTiming {
-                text_start: 0,
-                text_end: 5,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(0, 5)],
         };
         let session = session_with(spoken, spoken, vec![(spoken, 0, 10)], Some(caps));
         let (_, _, reason) = project_state(&session);
@@ -1190,12 +1174,7 @@ mod tests {
         let start = spoken.find(f2).unwrap();
         let captions = CaptionAlignment {
             text: f2.to_string(),
-            words: vec![WordTiming {
-                text_start: 5,
-                text_end: 8,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(5, 8)],
         };
         let session = session_with(
             raw,
@@ -1205,44 +1184,25 @@ mod tests {
         );
         session.active_fragment.store(1, Ordering::Relaxed);
         let (s, e) = current_word(&session).unwrap();
-        assert_eq!(&session.raw_text[s..e], "two");
+        assert_eq!(&raw[s..e], "two");
     }
 
-    /// Regression for the 2026-09-09 `word_available=false` gap. The wire
-    /// sends a text chunk (captions=None) BEFORE the caption item
-    /// (text=None); the old sticky `table.captions_ok=false` survived the
-    /// later caption arrival and degraded the whole reading to passage-only.
+    /// The wire sends a text chunk (captions=None) BEFORE the caption item
+    /// (text=None); the fragment only becomes usable once captions land.
     #[test]
-    fn late_captions_restore_table_captions_ok() {
+    fn late_captions_make_the_fragment_usable() {
         let text = "hello world";
-        let mut table = FragmentTable {
-            fragments: vec![FragmentEntry {
-                text_start: 0,
-                text_end: text.len(),
-                expected_text: text.to_string(),
-                captions: None,
-                captions_ok: false,
-            }],
-            tiling_ok: true,
-            captions_ok: true,
-        };
+        let mut fragments = vec![entry(text, 0, text.len())];
         let caps = CaptionAlignment {
             text: text.to_string(),
-            words: vec![WordTiming {
-                text_start: 0,
-                text_end: 5,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(0, 5)],
         };
 
-        // 1. Text chunk: captions=None, then
-        // 2. caption item: text=None (the ElevenLabs standalone stream item).
-        apply_fragment_event(&mut table, 0, Some(text), None);
-        assert!(!table.captions_ok);
-        apply_fragment_event(&mut table, 0, None, Some(caps));
+        apply_fragment_event(&mut fragments, 0, Some(text), None);
+        assert!(!fragments[0].captions_ok);
+        apply_fragment_event(&mut fragments, 0, None, Some(caps));
 
-        assert!(table.captions_ok, "late captions must clear the table flag");
+        assert!(fragments[0].captions_ok, "late captions must land");
     }
 
     /// A standalone caption item (text=None) must NOT be mistaken for foreign
@@ -1250,85 +1210,66 @@ mod tests {
     #[test]
     fn caption_only_event_skips_tile_check() {
         let text = "hello world";
-        let mut table = FragmentTable {
-            fragments: vec![FragmentEntry {
-                text_start: 0,
-                text_end: text.len(),
-                expected_text: text.to_string(),
-                captions: None,
-                captions_ok: false,
-            }],
-            tiling_ok: true,
-            captions_ok: true,
-        };
+        let mut fragments = vec![entry(text, 0, text.len())];
         let caps = CaptionAlignment {
             text: text.to_string(),
-            words: vec![WordTiming {
-                text_start: 0,
-                text_end: 5,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(0, 5)],
         };
-        apply_fragment_event(&mut table, 0, None, Some(caps));
+        apply_fragment_event(&mut fragments, 0, None, Some(caps));
 
-        assert!(table.tiling_ok, "tile check must not run on text=None");
-        assert!(table.captions_ok);
+        assert!(fragments[0].captions_ok);
     }
 
-    /// Captions whose text diverges from the expected tile still degrade the
+    /// A concurrent desktop reading's events name a different tile. They are
+    /// ignored, leaving captions this fragment already has intact.
+    #[test]
+    fn foreign_tile_events_are_ignored_not_fatal() {
+        let text = "hello world";
+        let mut fragments = vec![entry(text, 0, text.len())];
+        let caps = CaptionAlignment {
+            text: text.to_string(),
+            words: vec![word(0, 5)],
+        };
+        apply_fragment_event(&mut fragments, 0, None, Some(caps));
+        apply_fragment_event(
+            &mut fragments,
+            0,
+            Some("a different reading"),
+            Some(CaptionAlignment {
+                text: "a different reading".to_string(),
+                words: vec![word(0, 8)],
+            }),
+        );
+
+        assert!(fragments[0].captions_ok, "foreign events must not degrade");
+        assert_eq!(fragments[0].captions.as_ref().unwrap().text, text);
+    }
+
+    /// Captions whose text diverges from their own tile still degrade that
     /// fragment — the identity-mapping policy is unchanged.
     #[test]
     fn mismatched_captions_still_degrade() {
         let text = "hello world";
-        let mut table = FragmentTable {
-            fragments: vec![FragmentEntry {
-                text_start: 0,
-                text_end: text.len(),
-                expected_text: text.to_string(),
-                captions: None,
-                captions_ok: false,
-            }],
-            tiling_ok: true,
-            captions_ok: true,
-        };
+        let mut fragments = vec![entry(text, 0, text.len())];
         let caps = CaptionAlignment {
             text: "different text".to_string(),
-            words: vec![WordTiming {
-                text_start: 0,
-                text_end: 5,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(0, 5)],
         };
-        apply_fragment_event(&mut table, 0, Some(text), None);
-        apply_fragment_event(&mut table, 0, None, Some(caps));
+        apply_fragment_event(&mut fragments, 0, Some(text), None);
+        apply_fragment_event(&mut fragments, 0, Some(text), Some(caps));
 
-        assert!(!table.captions_ok);
-        assert!(table.tiling_ok);
+        assert!(!fragments[0].captions_ok);
     }
 
     /// Regression for the 2026-09-09 live-click failure: ElevenLabs pads its
     /// alignment text with one leading/trailing space (each pad char gets its
     /// own timing entry), so exact-identity matching degraded every reading.
-    /// Proven from history sidecars: caps.text " The Great Fiction-Nonfiction
-    /// Inversion " vs tile "The Great Fiction-Nonfiction Inversion".
     #[test]
     fn edge_padded_captions_are_rebased_to_tile() {
         let expected = "The Great Fiction-Nonfiction Inversion";
         let padded = format!(" {expected} ");
         let content_u16 = expected.encode_utf16().count();
-        let mut table = FragmentTable {
-            fragments: vec![FragmentEntry {
-                text_start: 0,
-                text_end: content_u16,
-                expected_text: expected.to_string(),
-                captions: None,
-                captions_ok: false,
-            }],
-            tiling_ok: true,
-            captions_ok: true,
-        };
+        let mut fragments = vec![entry(expected, 0, content_u16)];
         let caps = CaptionAlignment {
             text: padded,
             words: vec![
@@ -1348,56 +1289,37 @@ mod tests {
                 },
                 // Trailing pad "word".
                 WordTiming {
-                    text_start: (content_u16 + 1) as usize,
-                    text_end: (content_u16 + 2) as usize,
+                    text_start: content_u16 + 1,
+                    text_end: content_u16 + 2,
                     start_ms: 300.0,
                     end_ms: 350.0,
                 },
             ],
         };
-        apply_fragment_event(&mut table, 0, Some(expected), None);
-        apply_fragment_event(&mut table, 0, None, Some(caps));
+        apply_fragment_event(&mut fragments, 0, Some(expected), None);
+        apply_fragment_event(&mut fragments, 0, None, Some(caps));
 
-        assert!(
-            table.captions_ok,
-            "padded captions must rebase, not degrade"
-        );
-        let caps = table.fragments[0].captions.as_ref().unwrap();
+        assert!(fragments[0].captions_ok, "padded captions must rebase");
+        let caps = fragments[0].captions.as_ref().unwrap();
         assert_eq!(caps.text, expected);
         assert_eq!(caps.words.len(), 1, "pad-only words dropped");
         assert_eq!((caps.words[0].text_start, caps.words[0].text_end), (0, 4));
         assert_eq!(caps.words[0].start_ms, 58.0, "audio timings untouched");
     }
 
-    /// Interior divergence (normalized/rewritten caption text) still degrades
-    /// the fragment — the identity-mapping policy is unchanged.
+    /// Interior divergence (rewritten caption text) still degrades the
+    /// fragment — the identity-mapping policy is unchanged.
     #[test]
     fn interior_divergent_captions_still_degrade() {
-        let mut table = FragmentTable {
-            fragments: vec![FragmentEntry {
-                text_start: 0,
-                text_end: 12,
-                expected_text: "hello world!".to_string(),
-                captions: None,
-                captions_ok: false,
-            }],
-            tiling_ok: true,
-            captions_ok: true,
-        };
+        let mut fragments = vec![entry("hello world!", 0, 12)];
         let caps = CaptionAlignment {
             text: " hello worlds! ".to_string(),
-            words: vec![WordTiming {
-                text_start: 1,
-                text_end: 6,
-                start_ms: 0.0,
-                end_ms: 100.0,
-            }],
+            words: vec![word(1, 6)],
         };
-        apply_fragment_event(&mut table, 0, Some("hello world!"), None);
-        apply_fragment_event(&mut table, 0, None, Some(caps));
+        apply_fragment_event(&mut fragments, 0, Some("hello world!"), None);
+        apply_fragment_event(&mut fragments, 0, None, Some(caps));
 
-        assert!(!table.captions_ok);
-        assert!(table.tiling_ok);
+        assert!(!fragments[0].captions_ok);
     }
 
     /// The proven fragment-2 shape: edge padding PLUS curly→straight quote
@@ -1409,17 +1331,8 @@ mod tests {
             " {}",
             expected.replace('\u{201C}', "\"").replace('\u{201D}', "\"")
         );
-        let mut table = FragmentTable {
-            fragments: vec![FragmentEntry {
-                text_start: 0,
-                text_end: expected.encode_utf16().count(),
-                expected_text: expected.to_string(),
-                captions: None,
-                captions_ok: false,
-            }],
-            tiling_ok: true,
-            captions_ok: true,
-        };
+        let content_u16 = expected.encode_utf16().count();
+        let mut fragments = vec![entry(expected, 0, content_u16)];
         let mut padded_u16 = padded.encode_utf16().collect::<Vec<_>>();
         padded_u16.push(0x20); // trailing pad
         let caps = CaptionAlignment {
@@ -1433,28 +1346,28 @@ mod tests {
                 }, // lead pad
                 WordTiming {
                     text_start: 1,
-                    text_end: 1 + expected.encode_utf16().count(),
+                    text_end: 1 + content_u16,
                     start_ms: 20.0,
                     end_ms: 500.0,
                 },
                 WordTiming {
-                    text_start: (1 + expected.encode_utf16().count()) as usize,
-                    text_end: (2 + expected.encode_utf16().count()) as usize,
+                    text_start: 1 + content_u16,
+                    text_end: 2 + content_u16,
                     start_ms: 500.0,
                     end_ms: 520.0,
                 }, // trail pad
             ],
         };
-        apply_fragment_event(&mut table, 0, Some(expected), None);
-        apply_fragment_event(&mut table, 0, None, Some(caps));
+        apply_fragment_event(&mut fragments, 0, Some(expected), None);
+        apply_fragment_event(&mut fragments, 0, None, Some(caps));
 
-        assert!(table.captions_ok, "quote-normalized padding must rebase");
-        let caps = table.fragments[0].captions.as_ref().unwrap();
+        assert!(fragments[0].captions_ok, "quote-normalized padding rebases");
+        let caps = fragments[0].captions.as_ref().unwrap();
         assert_eq!(caps.text, expected);
         assert_eq!(caps.words.len(), 1);
         assert_eq!(
             (caps.words[0].text_start, caps.words[0].text_end),
-            (0, expected.encode_utf16().count())
+            (0, content_u16)
         );
     }
 }

--- a/src-tauri/src/sanitize/tts_normalize.rs
+++ b/src-tauri/src/sanitize/tts_normalize.rs
@@ -163,8 +163,8 @@ fn normalize_characters(text: &str) -> String {
 }
 
 /// The same-length subset only (substitutions + homoglyph folds, NO
-/// deletions). Used by `text_map` to prove a spoken text is the raw text
-/// under pure 1→1 substitutions, keeping word highlighting exact.
+/// deletions). Used by `text_map` to compare raw and spoken words under the
+/// folds the sanitizer applies, so a folded word still matches its source.
 pub(crate) fn canonical_same_length(text: &str) -> String {
     fold_homoglyphs(&substitute_same_length(text))
 }
@@ -388,8 +388,7 @@ fn expand_symbols(text: &str) -> String {
 // ── 11. Punctuation Normalization ───────────────────────────────────────────
 
 lazy_static::lazy_static! {
-    // Shared with source mapping so paired delimiters follow the same rule.
-    pub(crate) static ref PAREN_REGEX: Regex = Regex::new(r"\(([^)]+)\)").unwrap();
+    static ref PAREN_REGEX: Regex = Regex::new(r"\(([^)]+)\)").unwrap();
 }
 
 fn normalize_punctuation(text: &str) -> String {

--- a/src-tauri/src/text_map.rs
+++ b/src-tauri/src/text_map.rs
@@ -1,431 +1,362 @@
-//! Exact source↔spoken text mapping through whitespace normalization plus
-//! same-length punctuation/homoglyph substitution and known punctuation rewrites.
+//! Order-preserving word alignment between the raw selection and the spoken
+//! (sanitized) text.
 //!
-//! Browser companion needs word offsets in the RAW selected text, while
-//! synthesis speaks sanitized text. When sanitization only collapsed
-//! whitespace and/or applied pure 1 UTF-16 unit → 1 unit character
-//! substitutions (curly→straight quotes, en-dash→hyphen, Cyrillic→Latin
-//! homoglyphs, unicode spaces), the mapping is exact: every spoken char came
-//! from one known source char. Em-dashes, ellipses, and paired parentheses carry
-//! their source positions through comma/space rewriting and artifact cleanup.
-//! Anything else (URL rewriting, citation removal, LLM post-processing) degrades
-//! to passage-only highlighting upstream. No fuzzy matching.
+//! The browser companion needs caption word offsets in the RAW selected text,
+//! while synthesis speaks sanitized text. Sanitization is a chain of regex
+//! rewrites that carries no provenance, so this module used to *replay* a
+//! hand-picked subset of them (whitespace collapse, same-length folds,
+//! em-dash/ellipsis/parenthesis rewrites) and reject everything else. That made
+//! word highlighting all-or-nothing for a whole reading, and a single `%`
+//! expanding to " percent" was enough to switch it off (2026-09-10).
+//!
+//! Instead of a second, partial implementation of the sanitizer, align the two
+//! texts' word tokens directly: identical words map exactly, a rewritten run
+//! maps to the source run it replaced, and a word the sanitizer invented out of
+//! punctuation maps to that punctuation. Only the individual word that cannot
+//! be explained loses its highlight — never the reading.
 
-use crate::sanitize::{
-    cleanup::cleanup_artifacts,
-    tts_normalize::{canonical_same_length, PAREN_REGEX},
-};
+use crate::sanitize::tts_normalize::canonical_same_length;
 
-/// A spoken-text char → source-text char map (one source char per spoken char).
-#[derive(Debug, Clone, PartialEq)]
-pub struct WhitespaceMap {
-    /// `spoken_to_source[i]` = source char index of spoken char `i`.
-    spoken_to_source: Vec<usize>,
-    /// UTF-16 offset of each char boundary in the collapsed (spoken) text;
-    /// `offsets[i]` is the u16 offset of spoken char `i`, with a final entry
-    /// for the end of the text.
-    spoken_char_offsets: Vec<usize>,
+/// A UTF-16 `[start, end)` span — the browser's index space.
+type Span = (usize, usize);
+
+/// Most words the sanitizer can invent in place of one source run
+/// (`%` → "percent", `km/h` → "kilometers per hour"). Deletions are unbounded
+/// in the other direction: stripping a code block or a URL removes many source
+/// words at once.
+const MAX_INSERTED_WORDS: usize = 8;
+
+/// Spoken-word → source-word span map. Always constructible.
+pub struct TextAlignment {
+    /// Spoken word spans, ascending and non-overlapping.
+    spoken: Vec<Span>,
+    /// Source span each spoken word came from, `None` when nothing in the
+    /// source explains it.
+    source: Vec<Option<Span>>,
 }
 
-/// Collapse every run of whitespace to a single space and trim the ends.
-/// This mirrors the newline-stripping pass in the sanitizer closely enough
-/// that equality with `sanitize_text` output proves no other pass fired.
-pub fn collapse_whitespace(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut in_ws = false;
+/// Align `spoken` (the sanitized text) back onto `source` (the raw selection).
+pub fn align(source: &str, spoken: &str) -> TextAlignment {
+    let source_u16: Vec<u16> = source.encode_utf16().collect();
+    let (source_spans, source_keys) = tokenize(source);
+    let (spoken_spans, spoken_keys) = tokenize(spoken);
+    let mut mapped: Vec<Option<Span>> = vec![None; spoken_spans.len()];
+
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < source_keys.len() && j < spoken_keys.len() {
+        if source_keys[i] == spoken_keys[j] {
+            mapped[j] = Some(source_spans[i]);
+            i += 1;
+            j += 1;
+            continue;
+        }
+        let Some((di, dj)) = resync(&source_keys[i..], &spoken_keys[j..]) else {
+            // Nothing downstream lines up again: keep the highlight on the
+            // rest of the selection rather than drifting word by word.
+            let rest = Some((source_spans[i].0, source_spans[source_spans.len() - 1].1));
+            mapped[j..].fill(rest);
+            break;
+        };
+        // The rewritten spoken words came from the source words they replaced,
+        // or — for a pure insertion — from the punctuation between the
+        // surrounding words, which is what the sanitizer expanded.
+        let block = if di > 0 {
+            Some((source_spans[i].0, source_spans[i + di - 1].1))
+        } else {
+            gap_before(&source_u16, &source_spans, i)
+        };
+        mapped[j..j + dj].fill(block);
+        i += di;
+        j += dj;
+    }
+
+    TextAlignment {
+        spoken: spoken_spans,
+        source: mapped,
+    }
+}
+
+impl TextAlignment {
+    /// Map a UTF-16 span of the spoken text back to the raw selection.
+    ///
+    /// Returns the union of the source spans of every spoken word the range
+    /// touches. `None` when the range covers no word at all (punctuation-only
+    /// caption entries) or only words the sanitizer invented with no source.
+    pub fn source_span_utf16(&self, start: usize, end: usize) -> Option<Span> {
+        if start >= end {
+            return None;
+        }
+        // First spoken word that ends after `start`; spans are ascending.
+        let first = self.spoken.partition_point(|&(_, word_end)| word_end <= start);
+        let mut span: Option<Span> = None;
+        for (index, &(word_start, _)) in self.spoken.iter().enumerate().skip(first) {
+            if word_start >= end {
+                break;
+            }
+            let Some((source_start, source_end)) = self.source[index] else {
+                continue;
+            };
+            span = Some(match span {
+                Some((known_start, known_end)) => {
+                    (known_start.min(source_start), known_end.max(source_end))
+                }
+                None => (source_start, source_end),
+            });
+        }
+        span
+    }
+}
+
+/// Split text into maximal runs of alphanumeric characters, returning each
+/// run's UTF-16 span and a comparison key folded through the sanitizer's own
+/// same-length substitution table (curly quotes, dashes, homoglyphs, fullwidth
+/// forms) so a folded word still matches its source.
+///
+/// Punctuation is deliberately not part of a token: it is exactly what the
+/// sanitizer rewrites, and it is never the unit a caption highlights.
+///
+/// ponytail: alphanumeric runs, so a script written without word spacing (CJK)
+/// tokenizes as one long word and highlights the whole run; add script-aware
+/// segmentation if a voice for one of those ships.
+fn tokenize(text: &str) -> (Vec<Span>, Vec<String>) {
+    let mut spans = Vec::new();
+    let mut keys = Vec::new();
+    let mut offset = 0usize; // running UTF-16 offset
+    let mut current: Option<(usize, String)> = None;
     for ch in text.chars() {
-        if ch.is_whitespace() {
-            in_ws = true;
-        } else {
-            if in_ws && !out.is_empty() {
-                out.push(' ');
-            }
-            in_ws = false;
-            out.push(ch);
-        }
-    }
-    out
-}
-
-/// Build an exact map through whitespace, same-length substitutions, and
-/// em-dash/ellipsis/parenthesis rewrites. Unexplained differences remain unmappable.
-pub fn whitespace_map(source: &str, collapsed: &str) -> Option<WhitespaceMap> {
-    let collapsed_form = collapse_whitespace(source);
-    let mut spoken_to_source: Vec<usize> = Vec::with_capacity(collapsed.chars().count());
-    let mut spoken_char_offsets: Vec<usize> = Vec::with_capacity(collapsed.chars().count() + 1);
-    let mut source_index = 0usize;
-    let mut u16_offset = 0usize; // running UTF-16 offset in the collapsed text
-    let mut pending_ws = false;
-    for ch in source.chars() {
-        if ch.is_whitespace() {
-            pending_ws = true;
-            source_index += 1;
-        } else {
-            if pending_ws && !spoken_to_source.is_empty() {
-                // The inserted space points at the last source whitespace char.
-                spoken_to_source.push(source_index - 1);
-                spoken_char_offsets.push(u16_offset);
-                u16_offset += 1; // the inserted space is one UTF-16 unit
-            }
-            pending_ws = false;
-            spoken_to_source.push(source_index);
-            spoken_char_offsets.push(u16_offset);
-            u16_offset += ch.len_utf16();
-            source_index += 1;
-        }
-    }
-    spoken_char_offsets.push(u16_offset);
-    let map = WhitespaceMap {
-        spoken_to_source,
-        spoken_char_offsets,
-    };
-    let canonical = canonical_same_length(&collapsed_form);
-    if collapsed == collapsed_form || collapsed == canonical {
-        return Some(map);
-    }
-    punctuation_map(&canonical, collapsed, map)
-}
-
-/// Replay only the approved rewrites with provenance, then compose the known
-/// cleanup deletions/space insertions. Never search ahead for matching words.
-fn punctuation_map(source: &str, spoken: &str, map: WhitespaceMap) -> Option<WhitespaceMap> {
-    let mut delimiters = std::collections::BTreeMap::new();
-    for matched in PAREN_REGEX.find_iter(source) {
-        delimiters.insert(matched.start(), true);
-        delimiters.insert(matched.end() - 1, false);
-    }
-    if delimiters.is_empty() && !source.contains(['—', '…']) {
-        return None;
-    }
-    let mut rewritten = Vec::new();
-    for ((byte, ch), origin) in source.char_indices().zip(map.spoken_to_source) {
-        match delimiters.get(&byte) {
-            Some(true) => rewritten.extend([(',', origin), (' ', origin)]),
-            Some(false) => rewritten.push((',', origin)),
-            None if ch == '—' => rewritten.extend([(',', origin), (' ', origin)]),
-            None if ch == '…' => rewritten.extend([('.', origin); 3]),
-            None => rewritten.push((ch, origin)),
-        }
-    }
-    let text: String = rewritten.iter().map(|&(ch, _)| ch).collect();
-    // Leading generated commas are stripped by sanitize_tts's orphan pass.
-    // Do not extend that permission to unrelated leading source punctuation.
-    let cleaned = cleanup_artifacts(&text);
-    let expected = if source.starts_with(['—', '(']) {
-        cleaned.trim_start_matches([',', ' '])
-    } else {
-        &cleaned
-    };
-    if expected != spoken {
-        return None;
-    }
-
-    let mut input = rewritten.into_iter().peekable();
-    let mut spoken_to_source = Vec::new();
-    let mut spoken_char_offsets = vec![0];
-    let mut offset = 0;
-    let mut previous_origin = 0;
-    for ch in spoken.chars() {
-        loop {
-            match input.peek().copied() {
-                Some((next, origin)) if next == ch => {
-                    input.next();
-                    previous_origin = origin;
-                    spoken_to_source.push(origin);
-                    break;
-                }
-                Some((' ' | ',', _)) => {
-                    input.next();
-                }
-                Some(_) if ch == ' ' => {
-                    // Cleanup inserts a space after a comma/colon/semicolon.
-                    spoken_to_source.push(previous_origin);
-                    break;
-                }
-                _ => return None,
-            }
+        if ch.is_alphanumeric() {
+            current
+                .get_or_insert_with(|| (offset, String::new()))
+                .1
+                .push(ch);
+        } else if let Some((start, word)) = current.take() {
+            spans.push((start, offset));
+            keys.push(canonical_same_length(&word));
         }
         offset += ch.len_utf16();
-        spoken_char_offsets.push(offset);
     }
-    // Cleanup can only discard spaces/commas from this rewritten candidate.
-    if input.any(|(ch, _)| !matches!(ch, ' ' | ',')) {
-        return None;
+    if let Some((start, word)) = current {
+        spans.push((start, offset));
+        keys.push(canonical_same_length(&word));
     }
-    Some(WhitespaceMap {
-        spoken_to_source,
-        spoken_char_offsets,
-    })
+    (spans, keys)
 }
 
-/// Diagnostic: where `spoken` stops being explainable as whitespace-collapse +
-/// supported normalization of `source`. Mirrors `whitespace_map`'s acceptance
-/// gate and includes bounded text excerpts for triage.
-pub fn first_divergence(source: &str, spoken: &str) -> Option<String> {
-    let collapsed_form = collapse_whitespace(source);
-    if whitespace_map(source, spoken).is_some() {
-        return None;
-    }
-    Some(format!(
-        "spoken differs from supported source normalization; collapse(source)={:?} ({} chars), spoken={:?} ({} chars)",
-        truncate_for_log(&collapsed_form),
-        collapsed_form.chars().count(),
-        truncate_for_log(spoken),
-        spoken.chars().count(),
-    ))
-}
-
-/// Bound log payloads when a divergence dump fires on huge selections.
-fn truncate_for_log(text: &str) -> String {
-    const MAX: usize = 160;
-    if text.chars().count() <= MAX {
-        return text.to_string();
-    }
-    let mut out: String = text.chars().take(MAX).collect();
-    out.push('…');
-    out
-}
-
-impl WhitespaceMap {
-    /// Map a UTF-16 span of the spoken text to the source text.
-    ///
-    /// `start` maps to its own source char; `end` is exclusive so it maps to
-    /// one past the source char of spoken char `end - 1`. Returns `None` when
-    /// a bound splits a surrogate pair — callers degrade to no word highlight.
-    pub fn source_span_utf16(
-        &self,
-        source: &str,
-        start: usize,
-        end: usize,
-    ) -> Option<(usize, usize)> {
-        let spoken_char_start = self.utf16_to_char_index(start)?;
-        let spoken_char_end = self.utf16_to_char_index(end)?;
-        if spoken_char_start >= spoken_char_end || spoken_char_end > self.spoken_to_source.len() {
-            return None;
+/// Smallest `(source_skip, spoken_skip)` that puts both streams back on a
+/// shared word, in ascending total displacement. Source skips are unbounded
+/// (a stripped code block deletes many words); spoken skips are capped at
+/// [`MAX_INSERTED_WORDS`].
+fn resync(source: &[String], spoken: &[String]) -> Option<(usize, usize)> {
+    for total in 1..source.len() + MAX_INSERTED_WORDS {
+        for spoken_skip in 0..=total.min(MAX_INSERTED_WORDS) {
+            let source_skip = total - spoken_skip;
+            if source_skip < source.len() && agrees(source, spoken, source_skip, spoken_skip) {
+                return Some((source_skip, spoken_skip));
+            }
         }
-        let char_to_u16: Vec<usize> = std::iter::once(0)
-            .chain(source.chars().scan(0usize, |acc, ch| {
-                *acc += ch.len_utf16();
-                Some(*acc)
-            }))
-            .collect();
-        let source_char_start = self.spoken_to_source[spoken_char_start];
-        let source_char_last = self.spoken_to_source[spoken_char_end - 1];
-        let source_start = *char_to_u16.get(source_char_start)?;
-        let source_end = *char_to_u16.get(source_char_last + 1)?;
-        debug_assert!(source_start < source_end && source_end <= source.encode_utf16().count());
-        Some((source_start, source_end))
     }
+    None
+}
 
-    /// Exact UTF-16 offset → spoken char index. `None` when the offset lands
-    /// inside a surrogate pair (not a char boundary) or past the end.
-    fn utf16_to_char_index(&self, offset: usize) -> Option<usize> {
-        // `partition_point` on strictly-less returns the index of the first
-        // entry >= offset, which equals the char index when `offset` is an
-        // exact char start and overshoots it when the offset splits a pair.
-        let idx = self.spoken_char_offsets.partition_point(|&o| o < offset);
-        if idx >= self.spoken_char_offsets.len() || self.spoken_char_offsets[idx] != offset {
-            return None;
-        }
-        Some(idx)
+/// True when the two streams share a word at the given skips. The word that
+/// follows must agree too when both streams still have one: a lone common word
+/// ("the") is far too weak an anchor to resynchronize on.
+fn agrees(source: &[String], spoken: &[String], source_skip: usize, spoken_skip: usize) -> bool {
+    let Some(word) = source.get(source_skip) else {
+        return false;
+    };
+    if spoken.get(spoken_skip) != Some(word) {
+        return false;
     }
+    match (source.get(source_skip + 1), spoken.get(spoken_skip + 1)) {
+        (Some(next_source), Some(next_spoken)) => next_source == next_spoken,
+        _ => true,
+    }
+}
+
+/// The source text between word `i - 1` and word `i`, trimmed of whitespace —
+/// the punctuation a purely inserted spoken word was expanded from (`%` →
+/// "percent"). `None` when the words are only separated by whitespace.
+fn gap_before(source: &[u16], spans: &[Span], i: usize) -> Option<Span> {
+    let mut start = if i == 0 { 0 } else { spans[i - 1].1 };
+    let mut end = spans.get(i).map_or(source.len(), |&(word_start, _)| word_start);
+    while start < end && is_space(source[start]) {
+        start += 1;
+    }
+    while end > start && is_space(source[end - 1]) {
+        end -= 1;
+    }
+    (start < end).then_some((start, end))
+}
+
+/// Whitespace test for a single UTF-16 unit. Surrogate halves are never
+/// whitespace, so treating them as non-space is exact.
+fn is_space(unit: u16) -> bool {
+    char::from_u32(unit as u32).is_some_and(char::is_whitespace)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn collapse_joins_paragraphs() {
-        assert_eq!(collapse_whitespace("a\n\nb"), "a b");
-        assert_eq!(collapse_whitespace("  x \t y  "), "x y");
-        assert_eq!(collapse_whitespace("no-change"), "no-change");
-        assert_eq!(collapse_whitespace("   "), "");
+    /// Slice `source` by UTF-16 offsets (the browser's index space).
+    fn utf16_slice(source: &str, (start, end): Span) -> String {
+        let units: Vec<u16> = source.encode_utf16().collect();
+        String::from_utf16_lossy(&units[start..end])
+    }
+
+    /// Map the spoken word `word` (its `occurrence`-th appearance) back to the
+    /// raw text and return what it highlights.
+    fn highlight(source: &str, spoken: &str, word: &str, occurrence: usize) -> Option<String> {
+        let byte = spoken
+            .match_indices(word)
+            .nth(occurrence)
+            .unwrap_or_else(|| panic!("{word:?} #{occurrence} not in {spoken:?}"))
+            .0;
+        let start = spoken[..byte].encode_utf16().count();
+        let end = start + word.encode_utf16().count();
+        align(source, spoken)
+            .source_span_utf16(start, end)
+            .map(|span| utf16_slice(source, span))
     }
 
     #[test]
-    fn map_round_trips_multiline() {
+    fn plain_whitespace_collapse_maps_every_word() {
         let source = "First para.\n\nSecond one here.";
-        let collapsed = collapse_whitespace(source);
-        let map = whitespace_map(source, &collapsed).unwrap();
-        let spoken_start = collapsed.find("Second").unwrap();
-        let (s, e) = map
-            .source_span_utf16(source, spoken_start, spoken_start + 6)
-            .unwrap();
-        assert_eq!(&source[s..e], "Second");
+        let spoken = "First para. Second one here.";
+        assert_eq!(highlight(source, spoken, "Second", 0).as_deref(), Some("Second"));
+        assert_eq!(highlight(source, spoken, "First", 0).as_deref(), Some("First"));
+    }
+
+    /// The live 2026-09-10 failure: one `%` in a 1,944-character selection
+    /// expanded to " percent", and the whole reading lost word highlighting.
+    #[test]
+    fn percent_expansion_costs_only_the_inserted_word() {
+        let source = "Around 10-20% of measles cases result in hospitalization.";
+        let spoken = crate::sanitize::sanitize_text(
+            source,
+            &crate::config::SanitizationConfig::default(),
+        );
+        assert!(spoken.contains("percent"), "{spoken:?}");
+        for word in ["Around", "10", "20", "of", "measles", "hospitalization"] {
+            assert_eq!(
+                highlight(source, &spoken, word, 0).as_deref(),
+                Some(word),
+                "{word:?} lost its origin"
+            );
+        }
+        // The invented word points at the punctuation it was expanded from.
+        assert_eq!(highlight(source, &spoken, "percent", 0).as_deref(), Some("%"));
     }
 
     #[test]
-    fn map_rejects_non_whitespace_transforms() {
-        let source = "See https://example.com/x now";
-        // Sanitizer rewrote the URL: not a whitespace collapse.
-        let rewritten = "See link now";
-        assert!(whitespace_map(source, rewritten).is_none());
+    fn deletions_do_not_drift_the_words_after_them() {
+        let source = "See https://example.com/x now, really now.";
+        let spoken = crate::sanitize::sanitize_text(
+            source,
+            &crate::config::SanitizationConfig::default(),
+        );
+        assert_eq!(highlight(source, &spoken, "See", 0).as_deref(), Some("See"));
+        assert_eq!(highlight(source, &spoken, "really", 0).as_deref(), Some("really"));
     }
 
     #[test]
-    fn map_accepts_same_length_punctuation_substitution() {
-        // Word/Docs-style curly quotes: sanitizer speaks the straight form.
-        let source = "The “platform” didn’t ship";
-        let spoken = "The \"platform\" didn't ship";
-        let map = whitespace_map(source, spoken).unwrap();
-        let (s, e) = map.source_span_utf16(source, 4, 14).unwrap();
-        assert_eq!(utf16_slice(source, s, e), "“platform”");
+    fn same_length_folds_still_map_to_the_raw_form() {
+        // Curly quotes and a Cyrillic homoglyph both fold 1 unit → 1 unit.
+        assert_eq!(
+            highlight("The \u{201C}platform\u{201D} shipped", "The \"platform\" shipped", "platform", 0)
+                .as_deref(),
+            Some("platform")
+        );
+        assert_eq!(
+            highlight("The \u{0441}at sat", "The cat sat", "cat", 0).as_deref(),
+            Some("\u{0441}at")
+        );
     }
 
     #[test]
-    fn map_accepts_homoglyph_fold() {
-        // Cyrillic а (0x0430) in the raw text folds to Latin 'a' when spoken.
-        let source = "The сat sat";
-        let spoken = "The cat sat";
-        let map = whitespace_map(source, spoken).unwrap();
-        let (s, e) = map.source_span_utf16(source, 4, 7).unwrap();
-        assert_eq!(utf16_slice(source, s, e), "сat");
-    }
-
-    #[test]
-    fn map_rejects_deletions() {
-        // Leading-comma strip and emoji removal are deletions, not
-        // same-length substitutions — they still degrade to passage-only.
-        let source = ", They didn’t know";
-        let spoken = "They didn't know";
-        assert!(whitespace_map(source, spoken).is_none());
-        let source = "Nice 👍 work";
-        let spoken = "Nice  work";
-        assert!(whitespace_map(source, spoken).is_none());
-    }
-
-    #[test]
-    fn map_handles_repeated_words_exactly() {
+    fn repeated_words_map_to_their_own_occurrence() {
         let source = "buffalo buffalo\nbuffalo";
-        let collapsed = collapse_whitespace(source);
-        let map = whitespace_map(source, &collapsed).unwrap();
-        // Third occurrence maps to the third occurrence, never the first.
-        let (s, e) = map.source_span_utf16(source, 16, 23).unwrap();
-        assert_eq!(&source[s..e], "buffalo");
-        assert_eq!(s, 16);
+        let spoken = "buffalo buffalo buffalo";
+        let alignment = align(source, spoken);
+        assert_eq!(alignment.source_span_utf16(16, 23), Some((16, 23)));
+        assert_eq!(alignment.source_span_utf16(0, 7), Some((0, 7)));
     }
 
+    #[test]
+    fn punctuation_only_and_empty_ranges_have_no_word() {
+        let alignment = align("a, b", "a, b");
+        assert_eq!(alignment.source_span_utf16(1, 2), None, "the comma");
+        assert_eq!(alignment.source_span_utf16(2, 2), None, "empty range");
+        assert_eq!(alignment.source_span_utf16(400, 410), None, "past the end");
+    }
+
+    #[test]
+    fn surrogate_pairs_keep_the_following_words_aligned() {
+        let source = "a \u{1F44D}\u{1F3FD} b\nc";
+        let spoken = "a  b c";
+        let alignment = align(source, spoken);
+        // Source UTF-16: a=0, sp=1, thumb=2..4, tone=4..6, sp=6, b=7, sp=8, c=9.
+        assert_eq!(alignment.source_span_utf16(3, 4), Some((7, 8)), "b, not the emoji");
+        assert_eq!(alignment.source_span_utf16(5, 6), Some((9, 10)));
+    }
+
+    /// Every word of real prose keeps its exact origin through the punctuation
+    /// rewrites (em dash, ellipsis, parentheses) the sanitizer applies.
     #[test]
     fn punctuation_rewrites_preserve_every_word_source_span() {
-        let gwern = "When I came across this quote, I was struck by its relevance to one of Eliezer Yudkowsky’s ‘beisutsukai’ posts about finding the successor to quantum mechanics, “The Failures of Eld Science”.\nI meant to write an essay on how interesting it is that we intellectually know that many of our current theories must be wrong, and even have pretty good ideas as to which ones, but we still cannot psychologically tackle them with the same energy as if we had some anomaly or paradox to explain, or have the benefit of hindsight. The students in Eliezer’s story know that quantum mechanics is wrong; someone with a well-verified observation contradicting quantum mechanics knows that it is wrong (replace ‘quantum’ with ‘classical’ as you wish). They will achieve better results than a battalion of conventional QMists.\nBut nothing quite gelled.";
+        let gwern = "When I came across this quote, I was struck by its relevance to one of Eliezer Yudkowsky\u{2019}s \u{2018}beisutsukai\u{2019} posts about finding the successor to quantum mechanics, \u{201C}The Failures of Eld Science\u{201D}.\nI meant to write an essay on how interesting it is that we intellectually know that many of our current theories must be wrong, and even have pretty good ideas as to which ones, but we still cannot psychologically tackle them with the same energy as if we had some anomaly or paradox to explain, or have the benefit of hindsight. The students in Eliezer\u{2019}s story know that quantum mechanics is wrong; someone with a well-verified observation contradicting quantum mechanics knows that it is wrong (replace \u{2018}quantum\u{2019} with \u{2018}classical\u{2019} as you wish). They will achieve better results than a battalion of conventional QMists.\nBut nothing quite gelled.";
         let words = regex::Regex::new(r"\p{L}+").unwrap();
         for source in [
             gwern,
-            "Anthropic — and previously OpenAI — has resigned.",
-            "buffalo (buffalo) buffalo — buffalo.",
+            "Anthropic \u{2014} and previously OpenAI \u{2014} has resigned.",
+            "buffalo (buffalo) buffalo \u{2014} buffalo.",
             "text (aside), more (another). After.",
-            "text(aside)more—After.",
-            "— Opening words (aside).",
+            "text(aside)more\u{2014}After.",
+            "\u{2014} Opening words (aside).",
             "(Opening words) after.",
-            "Text —",
-            "𝄞 Before (aside) after — final.",
-            "Before （aside） after.",
+            "Text \u{2014}",
+            "\u{1D11E} Before (aside) after \u{2014} final.",
+            "Before \u{FF08}aside\u{FF09} after.",
             "Before (outer (inner) end) after.",
-            "Your disclaimer fell wide… The factor I had in mind.",
-            "𝄞 Word… word — word… final.",
-            "“The Manhattan Project”, Brennan said, “was launched with a specific technological end in sight: a weapon of great power, in time of war. But the error that Eld Science committed with respect to quantum physics had no immediate consequences for their technology. They were confused, but they had no desperate need for an answer. Otherwise the surrounding system would have removed all burdens from their effort to solve it. Surely the Manhattan Project must have done so—Taji? Do you know?”",
+            "Your disclaimer fell wide\u{2026} The factor I had in mind.",
+            "\u{1D11E} Word\u{2026} word \u{2014} word\u{2026} final.",
+            ", They didn\u{2019}t know the answer.",
+            "Nice \u{1F44D} work, everyone.",
         ] {
             let spoken = crate::sanitize::sanitize_text(
                 source,
                 &crate::config::SanitizationConfig::default(),
             );
-            let map = whitespace_map(source, &spoken)
-                .unwrap_or_else(|| panic!("Rejected {source:?} -> {spoken:?}"));
-            assert_eq!(first_divergence(source, &spoken), None);
+            let alignment = align(source, &spoken);
             let source_words: Vec<_> = words.find_iter(source).collect();
             let spoken_words: Vec<_> = words.find_iter(&spoken).collect();
-            assert_eq!(source_words.len(), spoken_words.len());
+            assert_eq!(source_words.len(), spoken_words.len(), "{source:?}");
             for (raw, said) in source_words.into_iter().zip(spoken_words) {
                 let start = spoken[..said.start()].encode_utf16().count();
                 let end = start + said.as_str().encode_utf16().count();
                 assert_eq!(
-                    map.source_span_utf16(source, start, end),
+                    alignment.source_span_utf16(start, end),
                     Some((
                         source[..raw.start()].encode_utf16().count(),
                         source[..raw.end()].encode_utf16().count(),
                     )),
-                    "Wrong origin for {:?} in {source:?}", said.as_str(),
+                    "Wrong origin for {:?} in {source:?}",
+                    said.as_str(),
                 );
             }
-            if source.starts_with('𝄞') {
-                assert_eq!(map.source_span_utf16(source, 0, 2), Some((0, 2)));
-                assert_eq!(map.source_span_utf16(source, 1, 2), None);
-            }
-            if let Some(byte) = source.find('…') {
-                let origin = source[..byte].encode_utf16().count();
-                let start = spoken[..spoken.find("...").unwrap()].encode_utf16().count();
-                for offset in 0..3 {
-                    assert_eq!(
-                        map.source_span_utf16(source, start + offset, start + offset + 1),
-                        Some((origin, origin + 1)),
-                    );
-                }
-            }
         }
     }
 
+    /// A wholesale rewrite has no anchors left; the highlight stays on the
+    /// remaining selection instead of walking off onto unrelated words.
     #[test]
-    fn punctuation_mapping_still_rejects_unexplained_changes() {
-        for (source, spoken) in [
-            ("Same — same same.", "Same, same."),
-            ("Same (same) same.", "Same, different, same."),
-            ("See — https://example.com now.", "See, link now."),
-            ("Nice — 👍 work.", "Nice, work."),
-            ("Wait — … now.", "Wait, now."),
-            ("Before (unclosed after.", "Before, unclosed after."),
-        ] {
-            assert!(whitespace_map(source, spoken).is_none(), "{source:?}");
-            assert!(first_divergence(source, spoken).is_some());
-        }
-    }
-
-    #[test]
-    fn map_leading_whitespace() {
-        let source = "\n\nLeading words";
-        let collapsed = collapse_whitespace(source);
-        let map = whitespace_map(source, &collapsed).unwrap();
-        let (s, e) = map.source_span_utf16(source, 0, 7).unwrap();
-        assert_eq!(&source[s..e], "Leading");
-    }
-
-    /// Slice `source` by UTF-16 offsets (the browser's index space).
-    fn utf16_slice(source: &str, start: usize, end: usize) -> String {
-        let units: Vec<u16> = source.encode_utf16().collect();
-        String::from_utf16_lossy(&units[start..end])
-    }
-
-    #[test]
-    fn map_survives_emoji() {
-        let source = "a 👍🏽 b\nc";
-        let collapsed = collapse_whitespace(source);
-        assert_eq!(collapsed, "a 👍🏽 b c");
-        let map = whitespace_map(source, &collapsed).unwrap();
-        // UTF-16 offsets: a=0, sp=1, 👍=2-3, 🏽=4-5, sp=6, b=7, sp=8, c=9.
-        let (s, e) = map.source_span_utf16(source, 7, 8).unwrap();
-        assert_eq!(utf16_slice(source, s, e), "b");
-        // A bound inside a surrogate pair is rejected, not mis-mapped.
-        assert!(map.source_span_utf16(source, 3, 4).is_none());
-        let (s, e) = map.source_span_utf16(source, 9, 10).unwrap();
-        assert_eq!(utf16_slice(source, s, e), "c");
-    }
-
-    #[test]
-    fn first_divergence_flags_real_divergence_and_accepts_clean_text() {
-        // A deletion (leading-comma strip) diverges and gets flagged.
-        let source = ", They didn’t know";
-        let spoken = crate::sanitize::sanitize_text(
-            source,
-            &crate::config::SanitizationConfig::default(),
-        );
-        assert!(first_divergence(source, &spoken).is_some());
-
-        // The live 2026-09-09 false degrade: plain-ASCII selection, one char
-        // missing after sanitization. Whatever the culprit pass, this pins
-        // the diagnostic contract: clean text reports None, mutated text
-        // reports Some.
-        let plain = "This is the strange state we're in: the system could do almost anything, but it requires the user to already know what to ask for. Too much of the work of discovering what's possible falls on the person, when it should fall on the system. You'd expect something this advanced to reveal its own capabilities, gradually, contextually, in ways that match your actual work. We're not there yet.";
-        assert_eq!(first_divergence(plain, plain), None);
-        assert!(first_divergence(plain, &format!("{plain}!")).is_some());
+    fn unrecoverable_divergence_falls_back_to_the_remaining_passage() {
+        let source = "alpha bravo charlie delta";
+        let spoken = "alpha zulu yankee xray";
+        let alignment = align(source, spoken);
+        assert_eq!(alignment.source_span_utf16(0, 5), Some((0, 5)), "alpha still exact");
+        let (start, end) = alignment.source_span_utf16(6, 10).unwrap();
+        assert_eq!(utf16_slice(source, (start, end)), "bravo charlie delta");
     }
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.2.0";
+export const VERSION = "0.2.1";


### PR DESCRIPTION
## What changed

Two bugs in the browser companion, both root-caused rather than patched at the symptom.

### 1. Word highlighting was off for any real paragraph

`src-tauri/src/text_map.rs` was a **second, partial implementation of the sanitizer**. It replayed a hand-picked subset of rewrites (whitespace collapse, same-length folds, em-dash/ellipsis/paren) and rejected everything else — globally, for the whole reading. Proven from a live log: one `%` in `"Around 10-20% of measles cases"` expanded to `" percent"` (1944 → 1951 chars) and killed highlighting for the entire 1,944-char selection.

The replay machinery is deleted. New API: `align(source, spoken) -> TextAlignment` (always constructible) plus `source_span_utf16(start, end)`. It does an order-preserving word alignment — tokenize both texts into alphanumeric runs, fold keys through `canonical_same_length`, walk both streams, resynchronize on the nearest two-word agreement. Source skips are unbounded (a stripped code block deletes many words); spoken skips are capped at 8. A rewritten run maps to the source run it replaced, and an invented word maps to the punctuation it came from — so `"percent"` highlights `%`. Unrecoverable divergence parks the highlight on the remaining passage instead of drifting.

### 2. Verdicts were whole-reading and sticky

`table.captions_ok = fragments.iter().all(...)` meant every fragment had to be captioned before any word highlighted; with 4 fragments synthesized over ~55 s, highlighting only switched on near the end. `tiling_ok` was likewise sticky — one stray event from a concurrent desktop reading permanently degraded the browser session.

`FragmentTable` and both flags are gone (`fragments: Mutex<Vec<FragmentEntry>>` now). `degrade_reason` reads only the audible fragment, and foreign-tile events are ignored rather than fatal. The reasons `unmappable_sanitization` and `tiling_diverged` no longer exist; `captions_unavailable` is the only one left.

### 3. Kokoro aborted a whole reading on one bracket

A link-heavy selection failed synthesis outright:

```
ERROR: Kokoro cannot map pronunciation to model tokens: '[02:11'
[TTS][stream] failed during opening: ... (0 bytes received)
```

Measured against the real misaki frontend (espeak fallback) and Kokoro's actual vocab:

```
punct NOT in vocab: ['#','$','%','&',"'",'*','+','-','/','<','=','>','@','[','\',']','^','_','`','{','|','}','~']
'[02:11]'   BAD: [('[02:11', '[zˈiəɹO tˈu:ɪlˈɛvən', ['['])]
'02:11'     BAD: []
'10:30 a.m.' '50°C' '½ cup' 'x | y' '#tag' 'C++' '→' '✅'   BAD: []
```

So `:` is fine (it *is* in vocab), `]` maps to `)` which is also in vocab, and the single offender is a leading `[` that misaki attaches to the following token and passes through as a literal phoneme. `caption_batches` now filters phonemes to the vocab — leaked punctuation carries no sound — while a missing *letter* phoneme stays a hard error, because that is a genuine pronunciation gap.

This was deliberately **not** fixed in the Rust sanitizer. `[02:11]` is not a citation, and the leaking set is context-dependent (an isolated `[` is dropped by misaki, an attached one is not; `»` leaks too), so widening `remove_citations` would be whack-a-mole against a constraint that only the wrapper can see.

## Why this shape

All three fixes land at the one place every caller routes through, rather than at the call site that happened to be reported. The alignment rewrite is a net deletion (−650 / +519 lines overall).

## Notes for a reviewer

- Known ceiling marked with a `ponytail:` comment in `text_map.rs`: CJK tokenizes as one long run, so alignment is coarse there.
- The installed engine keeps its own copy of the wrapper under `%LOCALAPPDATA%/CopySpeak/engines/kokoro/scripts/`. Re-run `install-kokoro.ps1`, or copy the file and restart so the resident daemon reloads it.
- `finish_session` already sends a `state` frame with `"error"` before the pipe closes, so the extension *is* told synthesis failed — the frame just carries no reason string. Left alone; out of scope.

## Verification

- `cargo test` — 237 passed, 1 ignored
- `bun run check` — 0 errors, 0 warnings
- `bun run test` — 62 passed (10 files)
- `python scripts/test-caption-alignment.py` — 8 passed, including a new case that asserts `[02:11` survives with its source span intact. The pre-existing reject test switched from `?` to an unknown letter, since punctuation is no longer a reason to abort.
- End to end against the real model: `"Watch at [02:11] now, see [1] and [xyz] too."` → `OK -> out.wav`
- Plain-text highlighting confirmed by hand end to end before this PR.

## Adjacent findings — reported, not fixed

- `providers: ['CPUExecutionProvider']` on this install: Kokoro runs on CPU, ~15 s per 600-char fragment, despite the `os.add_dll_directory` CUDA work already in the tree.
- A one-shot `uv run` spawns a fresh Python per synthesis while `[LocalDaemon] kokoro ready` says a model is already resident — the stray CPU-eating process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
