### PR TITLE
fix(tts): degrade unusable caption metadata without dropping valid audio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 - Export Kokoro's duration-capable model under isolated Python 3.12; Kokoro 0.8.4's NumPy 1.x dependency cannot use the managed engine's Python 3.13 wheels.
 - Check credential presence without printing `.env` values; never grep secret files into command output.
 - Preserve native caption intervals with their generated audio through stream framing, cache/history replay, and sample-count-based fragment concatenation; never scale word timings by text weights.
+- Reject unusable caption metadata without rejecting valid PCM; propagate caption clears to live/cache/history consumers, keep audio/protocol errors fatal, and retain source text for untimed fragments when joining readings.
 - Route playback speed and pitch through `TimeStretcher` (SoundTouch `pitch` setter, then `stretch.tempo = speed / pitch`); keep `playbackRate` at 1 on PCM sources and track `ScheduledPosition` duration/offset/rate in native time.
 - On a rate change, re-stretch the native chunks of unstarted PCM sources; audio already rendered keeps the rate it was rendered at, since absolute start times do not move.
 - Drive HUD captions from the audible fragment's audio clock; synthesis events may describe a later fragment, and incoming PCM chunks must not resume a user-paused stream.
@@ -61,7 +62,7 @@ Keep active failure log short: entries for work not in `## Active work` move to 
 - KittenTTS 0.8.1 (the pinned wheel) takes only `KittenTTS(model_name, cache_dir)`; select the GPU by replacing `tts.model.session`, not with a `backend=` kwarg that only exists on `main`.
 - Map browser caption words onto the raw selection with `text_map::align`'s word alignment; never re-derive the sanitizer's rewrites in a second place, and keep the highlight verdict per word and per fragment rather than per reading.
 - Pass `uv init` its target directory positionally (`uv init --bare --name X <dir>`); uv 0.12+ hard-errors on `uv --project <dir> init`, which only shows up when creating a fresh engine project.
-- Filter Kokoro's misaki phonemes through the model vocab before inference; misaki emits unpronounceable punctuation (an unbalanced `[`) as a literal phoneme, and only a missing *letter* phoneme is a real pronunciation gap worth aborting on.
+- Filter Kokoro's misaki phonemes through the model vocab before inference; misaki emits unpronounceable punctuation (an unbalanced `[`) as a literal phoneme, and only a missing _letter_ phoneme is a real pronunciation gap worth aborting on.
 
 <!-- rtk-instructions v2 -->
 

--- a/src-tauri/src/commands/tts/synthesis.rs
+++ b/src-tauri/src/commands/tts/synthesis.rs
@@ -220,10 +220,19 @@ fn drain_chunk_stream(
                 on_chunk(chunk_index, &bytes, false, None);
                 chunk_index += 1;
             }
-            Some(ChunkItem::Captions(value)) => {
-                value.validate()?;
+            Some(ChunkItem::Captions(value)) if value.validate().is_ok() => {
                 on_chunk(chunk_index, &[], false, Some(&value));
                 captions = Some(value);
+            }
+            Some(ChunkItem::Captions(_)) | Some(ChunkItem::ClearCaptions) => {
+                log::warn!("Clearing rejected live stream captions; continuing audio");
+                if let Some(mut previous) = captions.take() {
+                    // None means "no update" on the existing live wire. Send
+                    // an empty valid snapshot to clear both live consumers,
+                    // while retaining None for saved/cache metadata.
+                    previous.words.clear();
+                    on_chunk(chunk_index, &[], false, Some(&previous));
+                }
             }
             Some(ChunkItem::Failed(reason)) => {
                 log::error!(
@@ -1336,6 +1345,67 @@ mod streaming_tests {
         assert_eq!(
             &wav.bytes[info.data_offset..info.data_offset + info.data_size],
             &expected
+        );
+    }
+
+    #[test]
+    fn invalid_captions_do_not_interrupt_live_audio_or_survive_in_history() {
+        let valid = CaptionAlignment {
+            text: "Hi".into(),
+            words: vec![crate::tts::captions::WordTiming {
+                text_start: 0,
+                text_end: 2,
+                start_ms: 0.0,
+                end_ms: 0.1,
+            }],
+        };
+        let mut invalid = valid.clone();
+        invalid.words[0].text_end = 9;
+        let cleared = CaptionAlignment {
+            text: valid.text.clone(),
+            words: Vec::new(),
+        };
+        for rejection in [ChunkItem::Captions(invalid), ChunkItem::ClearCaptions] {
+            let stream = stream_from_items(
+                vec![
+                    ChunkItem::Captions(valid.clone()),
+                    ChunkItem::Pcm(vec![1, 2]),
+                    rejection,
+                    ChunkItem::Pcm(vec![3, 4]),
+                ],
+                8000,
+            );
+            let mut seen = Vec::new();
+            let (speech, _) = drain_chunk_stream(stream, |idx, pcm, is_final, captions| {
+                seen.push((idx, pcm.to_vec(), is_final, captions.cloned()));
+            })
+            .unwrap();
+            assert_eq!(speech.bytes, pcm_to_wav(&[1, 2, 3, 4], &meta(8000)));
+            assert_eq!(speech.captions, None);
+            assert_eq!(
+                seen,
+                vec![
+                    (0, vec![], false, Some(valid.clone())),
+                    (0, vec![1, 2], false, None),
+                    (1, vec![], false, Some(cleared.clone())),
+                    (1, vec![3, 4], false, None),
+                    (2, vec![], true, None),
+                ]
+            );
+            // The existing frontend accepts this as a replacement snapshot;
+            // absent metadata on ordinary PCM events is not a clear command.
+            assert!(cleared.validate().is_ok());
+        }
+        let next = stream_from_items(
+            vec![
+                ChunkItem::Captions(valid.clone()),
+                ChunkItem::Pcm(vec![5, 6]),
+            ],
+            8000,
+        );
+        assert_eq!(
+            drain_chunk_stream(next, |_, _, _, _| {}).unwrap().0.captions,
+            Some(valid)
         );
     }
 

--- a/src-tauri/src/tts/captions.rs
+++ b/src-tauri/src/tts/captions.rs
@@ -90,12 +90,37 @@ pub fn concat_speech(fragments: Vec<(SpeechAudio, String)>) -> Result<SpeechAudi
         }
         let offset_ms =
             pcm.len() as f64 * 1000.0 / (meta.sample_rate as f64 * meta.channels as f64 * 2.0);
+        let pcm_start = pcm.len();
+        for sample in source.convert_samples::<i16>() {
+            pcm.extend_from_slice(&sample.to_le_bytes());
+        }
+        let duration_ms = (pcm.len() - pcm_start) as f64 * 1000.0
+            / (meta.sample_rate as f64 * meta.channels as f64 * 2.0);
+        let captions = speech.captions.filter(|captions| {
+            if let Err(error) = captions.validate() {
+                log::warn!("Ignoring invalid fragment captions during concatenation: {error}");
+                return false;
+            }
+            // Empty snapshots carry no usable timing. Keep the fragment's
+            // source text so later captions retain their joined text offsets.
+            if captions.words.is_empty() {
+                return false;
+            }
+            if captions
+                .words
+                .last()
+                .is_some_and(|word| word.end_ms > duration_ms)
+            {
+                log::warn!("Ignoring fragment captions extending beyond their audio");
+                return false;
+            }
+            true
+        });
         if !combined.text.is_empty() {
             combined.text.push(' ');
         }
         let text_offset = combined.text.encode_utf16().count();
-        if let Some(mut captions) = speech.captions {
-            captions.validate()?;
+        if let Some(mut captions) = captions {
             for word in &mut captions.words {
                 word.text_start += text_offset;
                 word.text_end += text_offset;
@@ -107,16 +132,19 @@ pub fn concat_speech(fragments: Vec<(SpeechAudio, String)>) -> Result<SpeechAudi
         } else {
             combined.text.push_str(&text);
         }
-        for sample in source.convert_samples::<i16>() {
-            pcm.extend_from_slice(&sample.to_le_bytes());
-        }
         format = Some(meta);
     }
     let meta = format.ok_or("No speech fragments to concatenate")?;
-    combined.validate()?;
+    let captions = match combined.validate() {
+        Ok(()) => (!combined.words.is_empty()).then_some(combined),
+        Err(error) => {
+            log::warn!("Ignoring invalid combined captions: {error}");
+            None
+        }
+    };
     Ok(SpeechAudio {
         bytes: super::stream::pcm_to_wav(&pcm, &meta),
-        captions: (!combined.words.is_empty()).then_some(combined),
+        captions,
     })
 }
 
@@ -192,6 +220,110 @@ mod tests {
         assert_eq!(read_sidecar(path), None);
         remove_sidecar(path);
         assert_eq!(read_sidecar(path), None);
+    }
+
+    #[test]
+    fn rejected_fragment_captions_preserve_audio_and_neighbor_timings() {
+        let meta = super::super::stream::AudioFormatMeta {
+            sample_rate: 8000,
+            channels: 1,
+            bits_per_sample: 16,
+        };
+        let make = |text: &str| SpeechAudio {
+            bytes: super::super::stream::pcm_to_wav(&vec![0; 16000], &meta),
+            captions: Some(CaptionAlignment {
+                text: text.into(),
+                words: vec![WordTiming {
+                    text_start: 0,
+                    text_end: text.encode_utf16().count(),
+                    start_ms: 100.0,
+                    end_ms: 300.0,
+                }],
+            }),
+        };
+        // Both invalid offsets and locally ordered timings beyond the audio
+        // must degrade only this fragment, not invalidate the joined reading.
+        for overrun in [false, true] {
+            let mut middle = make("wrong");
+            let word = &mut middle.captions.as_mut().unwrap().words[0];
+            if overrun {
+                word.end_ms = 2000.0;
+            } else {
+                word.text_end = 99;
+            }
+            let speech = concat_speech(vec![
+                (make("A"), "A".into()),
+                (middle, "😀 B".into()),
+                (make("C"), "C".into()),
+            ])
+            .unwrap();
+            let captions = speech.captions.unwrap();
+            assert_eq!(captions.text, "A 😀 B C");
+            assert_eq!(captions.words.len(), 2);
+            assert_eq!(captions.words[0].start_ms, 100.0);
+            assert_eq!(captions.words[0].end_ms, 300.0);
+            assert_eq!(captions.words[1].text_start, 7);
+            assert_eq!(captions.words[1].start_ms, 2100.0);
+            assert_eq!(captions.words[1].end_ms, 2300.0);
+            assert_eq!(
+                speech.bytes,
+                super::super::stream::pcm_to_wav(&vec![0; 48000], &meta)
+            );
+            assert!(captions.validate().is_ok());
+        }
+    }
+
+    #[test]
+    fn untimed_fragment_uses_source_text_between_timed_neighbors() {
+        let meta = super::super::stream::AudioFormatMeta {
+            sample_rate: 8000,
+            channels: 1,
+            bits_per_sample: 16,
+        };
+        let timed = |text: &str| SpeechAudio {
+            bytes: super::super::stream::pcm_to_wav(&vec![0; 16000], &meta),
+            captions: Some(CaptionAlignment {
+                text: text.into(),
+                words: vec![WordTiming {
+                    text_start: 0,
+                    text_end: text.encode_utf16().count(),
+                    start_ms: 100.0,
+                    end_ms: 300.0,
+                }],
+            }),
+        };
+        for captions in [
+            None,
+            Some(CaptionAlignment {
+                text: String::new(),
+                words: Vec::new(),
+            }),
+        ] {
+            let middle = SpeechAudio {
+                bytes: super::super::stream::pcm_to_wav(&vec![0; 16000], &meta),
+                captions,
+            };
+            let speech = concat_speech(vec![
+                (timed("A"), "A".into()),
+                (middle, "😀 B".into()),
+                (timed("C"), "C".into()),
+            ])
+            .unwrap();
+            let captions = speech.captions.unwrap();
+            assert_eq!(captions.text, "A 😀 B C");
+            assert_eq!(captions.words.len(), 2);
+            assert_eq!(captions.words[1].text_start, 7);
+            assert_eq!(captions.words[1].start_ms, 2100.0);
+            assert_eq!(
+                speech.bytes,
+                super::super::stream::pcm_to_wav(&vec![0; 48000], &meta)
+            );
+        }
+    }
+
+    #[test]
+    fn concatenation_still_rejects_undecodable_audio() {
+        assert!(concat_speech(vec![(vec![1, 2, 3].into(), "Hi".into())]).is_err());
     }
 
     #[test]

--- a/src-tauri/src/tts/cartesia.rs
+++ b/src-tauri/src/tts/cartesia.rs
@@ -616,6 +616,7 @@ mod tests {
                     match item {
                         ChunkItem::Pcm(bytes) => pcm.extend(bytes),
                         ChunkItem::Captions(value) => captions = Some(value),
+                        ChunkItem::ClearCaptions => captions = None,
                         ChunkItem::Failed(reason) => {
                             assert!(reason.contains("401"));
                             failed = true;

--- a/src-tauri/src/tts/elevenlabs.rs
+++ b/src-tauri/src/tts/elevenlabs.rs
@@ -981,6 +981,7 @@ mod tests {
                     eprintln!("snapshot {snapshots}: {} chars, last timestamp {:.1} ms, prior audio {:.1} ms", captions.text.chars().count(), captions.words.last().map(|w| w.end_ms).unwrap_or(0.0), bytes.len() as f64 / 48.0);
                     last = Some(captions);
                 }
+                ChunkItem::ClearCaptions => last = None,
                 ChunkItem::Failed(error) => panic!("Live caption probe failed: {error}"),
             }
         }
@@ -1067,7 +1068,7 @@ mod tests {
             .iter()
             .flat_map(|item| match item {
                 ChunkItem::Pcm(bytes) => bytes.clone(),
-                ChunkItem::Captions(_) => Vec::new(),
+                ChunkItem::Captions(_) | ChunkItem::ClearCaptions => Vec::new(),
                 ChunkItem::Failed(reason) => panic!("unexpected failure: {}", reason),
             })
             .collect();

--- a/src-tauri/src/tts/elevenlabs_timing.rs
+++ b/src-tauri/src/tts/elevenlabs_timing.rs
@@ -14,13 +14,15 @@ struct CharacterAlignment {
 #[derive(Deserialize)]
 struct Record {
     audio_base64: String,
-    normalized_alignment: Option<CharacterAlignment>,
-    alignment: Option<CharacterAlignment>,
+    // Deserialize optional metadata separately so its schema cannot reject audio.
+    normalized_alignment: Option<serde_json::Value>,
+    alignment: Option<serde_json::Value>,
 }
 
 pub(super) struct TimestampDecoder {
     pending: Vec<u8>,
     captions: CaptionAlignment,
+    alignment_active: bool,
 }
 
 impl TimestampDecoder {
@@ -31,6 +33,7 @@ impl TimestampDecoder {
                 text: String::new(),
                 words: Vec::new(),
             },
+            alignment_active: true,
         }
     }
 
@@ -59,34 +62,34 @@ impl TimestampDecoder {
             let pcm = STANDARD
                 .decode(&record.audio_base64)
                 .map_err(|e| format!("Invalid ElevenLabs audio: {e}"))?;
-            if let Some(alignment) = record.normalized_alignment.or(record.alignment) {
-                if alignment.characters.len() != alignment.character_start_times_seconds.len()
-                    || alignment.characters.len() != alignment.character_end_times_seconds.len()
-                {
-                    return Err("ElevenLabs alignment arrays have different lengths".into());
-                }
-                let mut offset = self.captions.text.encode_utf16().count();
-                for ((character, start), end) in alignment
-                    .characters
-                    .into_iter()
-                    .zip(alignment.character_start_times_seconds)
-                    .zip(alignment.character_end_times_seconds)
-                {
-                    let next = offset + character.encode_utf16().count();
-                    if next == offset {
-                        continue;
+            if self.alignment_active {
+                let result = match record.normalized_alignment.or(record.alignment) {
+                    Some(value) => serde_json::from_value::<CharacterAlignment>(value)
+                        .map_err(|e| format!("Invalid ElevenLabs alignment schema: {e}"))
+                        .and_then(|alignment| {
+                            if !pcm.is_empty() && alignment.characters.iter().all(String::is_empty)
+                            {
+                                return Err("ElevenLabs audio has empty alignment".into());
+                            }
+                            self.extend_captions(alignment)
+                        })
+                        .map(|()| true),
+                    None if pcm.is_empty() => Ok(false),
+                    None => Err("ElevenLabs audio has no alignment".into()),
+                };
+                match result {
+                    Ok(true) => items.push(ChunkItem::Captions(self.captions.clone())),
+                    Ok(false) => {}
+                    Err(error) => {
+                        log::warn!("Disabling ElevenLabs captions for this fragment: {error}");
+                        // Later records are deltas. After a gap, their source
+                        // offsets cannot be recovered by appending to the prefix.
+                        self.alignment_active = false;
+                        self.captions.text.clear();
+                        self.captions.words.clear();
+                        items.push(ChunkItem::ClearCaptions);
                     }
-                    self.captions.text.push_str(&character);
-                    self.captions.words.push(WordTiming {
-                        text_start: offset,
-                        text_end: next,
-                        start_ms: start * 1000.0,
-                        end_ms: end * 1000.0,
-                    });
-                    offset = next;
                 }
-                self.captions.validate()?;
-                items.push(ChunkItem::Captions(self.captions.clone()));
             }
             // Metadata is delivered before its audio can become audible.
             if !pcm.is_empty() {
@@ -94,6 +97,40 @@ impl TimestampDecoder {
             }
         }
         Ok(items)
+    }
+
+    fn extend_captions(&mut self, alignment: CharacterAlignment) -> Result<(), String> {
+        if alignment.characters.len() != alignment.character_start_times_seconds.len()
+            || alignment.characters.len() != alignment.character_end_times_seconds.len()
+        {
+            return Err("ElevenLabs alignment arrays have different lengths".into());
+        }
+        // Commit only after validation; never mutate previously emitted intervals
+        // with part of a malformed cumulative update.
+        let mut captions = self.captions.clone();
+        let mut offset = captions.text.encode_utf16().count();
+        for ((character, start), end) in alignment
+            .characters
+            .into_iter()
+            .zip(alignment.character_start_times_seconds)
+            .zip(alignment.character_end_times_seconds)
+        {
+            let next = offset + character.encode_utf16().count();
+            if next == offset {
+                continue;
+            }
+            captions.text.push_str(&character);
+            captions.words.push(WordTiming {
+                text_start: offset,
+                text_end: next,
+                start_ms: start * 1000.0,
+                end_ms: end * 1000.0,
+            });
+            offset = next;
+        }
+        captions.validate()?;
+        self.captions = captions;
+        Ok(())
     }
 }
 
@@ -141,14 +178,149 @@ mod tests {
     }
 
     #[test]
-    fn rejects_mismatched_arrays_and_malformed_audio() {
+    fn rejects_malformed_audio_and_record_framing() {
         for input in [
             r#"{"audio_base64":"!"}"#,
-            r#"{"audio_base64":"", "normalized_alignment":{"characters":["a"],"character_start_times_seconds":[],"character_end_times_seconds":[]}}"#,
+            r#"{"audio_base64":123, "alignment":{}}"#,
+            r#"{"alignment":{}}"#,
+            "not json",
         ] {
             assert!(TimestampDecoder::new()
                 .push(input.as_bytes(), true)
                 .is_err());
         }
+    }
+
+    fn timed_record(character: &str, start: f64) -> String {
+        serde_json::json!({"audio_base64": "AQI=", "alignment": {
+            "characters": [character],
+            "character_start_times_seconds": [start],
+            "character_end_times_seconds": [start + 0.1]
+        }})
+        .to_string()
+            + "\n"
+    }
+
+    #[test]
+    fn unusable_alignment_preserves_audio_without_resuming_shifted_captions() {
+        let bad_alignments = [
+            serde_json::Value::Null,
+            serde_json::json!("wrong schema"),
+            serde_json::json!({"characters": ["B"], "character_start_times_seconds": [], "character_end_times_seconds": []}),
+            serde_json::json!({"characters": ["B"], "character_start_times_seconds": ["wrong type"], "character_end_times_seconds": [0.3]}),
+            serde_json::json!({"characters": ["B"], "character_start_times_seconds": [0.3], "character_end_times_seconds": [0.2]}),
+            serde_json::json!({"characters": ["B"], "character_start_times_seconds": [-1.0], "character_end_times_seconds": [0.3]}),
+            serde_json::json!({"characters": ["B"], "character_start_times_seconds": [0.0], "character_end_times_seconds": [0.1]}),
+            serde_json::json!({"characters": [], "character_start_times_seconds": [], "character_end_times_seconds": []}),
+        ];
+        for alignment in bad_alignments {
+            let mut decoder = TimestampDecoder::new();
+            let first = decoder
+                .push(timed_record("A", 0.1).as_bytes(), false)
+                .unwrap();
+            let ChunkItem::Captions(prefix) = &first[0] else {
+                panic!("expected initial valid captions")
+            };
+            let bad = serde_json::json!({"audio_base64": "AwQ=", "normalized_alignment": alignment})
+                .to_string() + "\n";
+            let rest = bad + &timed_record("C", 1.0);
+            assert_eq!(
+                decoder.push(rest.as_bytes(), true).unwrap(),
+                vec![
+                    ChunkItem::ClearCaptions,
+                    ChunkItem::Pcm(vec![3, 4]),
+                    ChunkItem::Pcm(vec![1, 2]),
+                ]
+            );
+            // Previously returned metadata is unchanged, but no stale snapshot
+            // remains in the decoder or gets extended across the missing B.
+            assert_eq!(prefix.text, "A");
+            assert!(decoder.captions.text.is_empty());
+            assert!(decoder.captions.words.is_empty());
+            let next = TimestampDecoder::new()
+                .push(timed_record("C", 0.1).as_bytes(), true)
+                .unwrap();
+            assert!(matches!(&next[0], ChunkItem::Captions(c) if c.text == "C"));
+        }
+    }
+
+    #[test]
+    fn malformed_caption_schema_survives_arbitrary_transport_splits() {
+        let input = "{\"audio_base64\":\"AQI=\",\"alignment\":{}}\n";
+        for split in 0..input.len() {
+            let mut decoder = TimestampDecoder::new();
+            assert!(decoder
+                .push(&input.as_bytes()[..split], false)
+                .unwrap()
+                .is_empty());
+            assert_eq!(
+                decoder.push(&input.as_bytes()[split..], true).unwrap(),
+                vec![ChunkItem::ClearCaptions, ChunkItem::Pcm(vec![1, 2])]
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_provider_metadata_cannot_survive_stream_collection() {
+        let wire = timed_record("A", 0.1)
+            + "{\"audio_base64\":\"AwQ=\",\"alignment\":{}}\n"
+            + &timed_record("C", 1.0);
+        let mut decoder = TimestampDecoder::new();
+        let (tx, rx) = std::sync::mpsc::channel();
+        for item in decoder.push(wire.as_bytes(), true).unwrap() {
+            tx.send(item).unwrap();
+        }
+        drop(tx);
+        let meta = super::super::stream::AudioFormatMeta {
+            sample_rate: 24000,
+            channels: 1,
+            bits_per_sample: 16,
+        };
+        let expected = super::super::stream::pcm_to_wav(&[1, 2, 3, 4, 1, 2], &meta);
+        let speech =
+            super::super::stream::collect_speech(super::super::stream::ChunkStream::new(meta, rx))
+                .unwrap();
+        assert_eq!(speech.bytes, expected);
+        assert_eq!(speech.captions, None);
+    }
+
+    #[test]
+    fn caption_degradation_does_not_disable_audio_validation() {
+        let mut decoder = TimestampDecoder::new();
+        assert_eq!(
+            decoder
+                .push(b"{\"audio_base64\":\"AQI=\",\"alignment\":{}}\n", false)
+                .unwrap(),
+            vec![ChunkItem::ClearCaptions, ChunkItem::Pcm(vec![1, 2])]
+        );
+        assert!(decoder
+            .push(b"{\"audio_base64\":\"!\"}\n", true)
+            .unwrap_err()
+            .contains("Invalid ElevenLabs audio"));
+    }
+
+    #[test]
+    fn absent_alignment_only_disables_captions_when_audio_is_present() {
+        let mut decoder = TimestampDecoder::new();
+        assert!(decoder
+            .push(b"{\"audio_base64\":\"\"}\n", false)
+            .unwrap()
+            .is_empty());
+        let first = decoder
+            .push(timed_record("A", 0.1).as_bytes(), false)
+            .unwrap();
+        assert!(matches!(&first[0], ChunkItem::Captions(_)));
+        assert_eq!(
+            decoder
+                .push(b"{\"audio_base64\":\"AQI=\"}\n", false)
+                .unwrap(),
+            vec![ChunkItem::ClearCaptions, ChunkItem::Pcm(vec![1, 2])]
+        );
+        assert_eq!(
+            decoder
+                .push(timed_record("C", 1.0).as_bytes(), true)
+                .unwrap(),
+            vec![ChunkItem::Pcm(vec![1, 2])]
+        );
     }
 }

--- a/src-tauri/src/tts/local_daemon.rs
+++ b/src-tauri/src/tts/local_daemon.rs
@@ -101,20 +101,36 @@ fn read_header(reader: &mut impl BufRead) -> Result<AudioFormatMeta, String> {
 /// `{"end":true}` marker.
 fn read_item(reader: &mut impl BufRead) -> Result<Option<ChunkItem>, String> {
     let frame = read_json_line(reader)?;
-    if let Some(captions) = frame.get("captions") {
-        let captions: super::captions::CaptionAlignment =
-            serde_json::from_value(captions.clone()).map_err(|e| e.to_string())?;
-        captions.validate()?;
-        return Ok(Some(ChunkItem::Captions(captions)));
-    }
-    if frame["end"].as_bool() == Some(true) {
-        return Ok(None);
-    }
+    // Optional metadata must never mask an explicit engine failure.
     if frame["ok"].as_bool() == Some(false) {
         return Err(frame["error"]
             .as_str()
             .unwrap_or("unknown daemon error")
             .to_string());
+    }
+    if let Some(captions) = frame.get("captions") {
+        // Only a caption-only frame can degrade safely. A mixed frame could
+        // own binary bytes; ignoring it would desynchronize the pipe.
+        if frame.as_object().is_none_or(|object| object.len() != 1) {
+            return Err("unexpected mixed caption frame".into());
+        }
+        let captions =
+            serde_json::from_value::<super::captions::CaptionAlignment>(captions.clone())
+                .map_err(|e| e.to_string())
+                .and_then(|captions| {
+                    captions.validate()?;
+                    Ok(captions)
+                });
+        return Ok(Some(match captions {
+            Ok(captions) => ChunkItem::Captions(captions),
+            Err(error) => {
+                log::warn!("Clearing invalid daemon captions: {error}");
+                ChunkItem::ClearCaptions
+            }
+        }));
+    }
+    if frame["end"].as_bool() == Some(true) {
+        return Ok(None);
     }
     let Some(len) = frame["chunk"].as_u64() else {
         return Err(format!("unexpected frame: {frame}"));
@@ -427,6 +443,54 @@ mod tests {
         };
         assert_eq!(captions.words[0].start_ms, 120.0);
         assert_eq!(read_item(&mut reader), Ok(Some(ChunkItem::Pcm(vec![1, 2]))));
+        assert_eq!(read_item(&mut reader), Ok(None));
+    }
+
+    #[test]
+    fn invalid_caption_frames_clear_metadata_without_consuming_audio_or_next_reply() {
+        let valid = b"{\"captions\":{\"text\":\"Hi\",\"words\":[{\"text_start\":0,\"text_end\":2,\"start_ms\":0,\"end_ms\":1}]}}\n";
+        let mut wire = valid.to_vec();
+        wire.extend_from_slice(b"{\"chunk\":2}\n\x01\x02");
+        // A long run must be consumed iteratively, not recursively.
+        for _ in 0..4096 {
+            wire.extend_from_slice(b"{\"captions\":{}}\n");
+        }
+        wire.extend_from_slice(b"{\"captions\":{\"text\":\"Hi\",\"words\":[{\"text_start\":0,\"text_end\":9,\"start_ms\":0,\"end_ms\":1}]}}\n");
+        wire.extend_from_slice(b"{\"chunk\":2}\n\x03\x04{\"end\":true}\n");
+        wire.extend_from_slice(valid);
+        wire.extend_from_slice(b"{\"end\":true}\n");
+        let mut reader = std::io::BufReader::new(&wire[..]);
+        let first = read_item(&mut reader).unwrap();
+        assert!(matches!(first, Some(ChunkItem::Captions(_))));
+        assert_eq!(read_item(&mut reader), Ok(Some(ChunkItem::Pcm(vec![1, 2]))));
+        for _ in 0..4096 {
+            assert_eq!(read_item(&mut reader), Ok(Some(ChunkItem::ClearCaptions)));
+        }
+        assert_eq!(read_item(&mut reader), Ok(Some(ChunkItem::ClearCaptions)));
+        assert_eq!(read_item(&mut reader), Ok(Some(ChunkItem::Pcm(vec![3, 4]))));
+        assert_eq!(read_item(&mut reader), Ok(None));
+        assert_eq!(read_item(&mut reader), Ok(first));
+        assert_eq!(read_item(&mut reader), Ok(None));
+    }
+
+    #[test]
+    fn caption_degradation_does_not_hide_protocol_errors() {
+        for suffix in [
+            "not json\n",
+            "{\"unexpected\":true}\n",
+            "{\"ok\":false,\"error\":\"engine failed\",\"captions\":{}}\n",
+            "{\"chunk\":8}\nabc",
+            "{\"captions\":{},\"chunk\":2}\nxx",
+            "",
+        ] {
+            let wire = format!("{{\"captions\":{{}}}}\n{suffix}");
+            let mut reader = std::io::BufReader::new(wire.as_bytes());
+            assert_eq!(read_item(&mut reader), Ok(Some(ChunkItem::ClearCaptions)));
+            assert!(read_item(&mut reader).is_err());
+        }
+        let wire = b"{\"captions\":null}\n{\"end\":true}\n";
+        let mut reader = std::io::BufReader::new(&wire[..]);
+        assert_eq!(read_item(&mut reader), Ok(Some(ChunkItem::ClearCaptions)));
         assert_eq!(read_item(&mut reader), Ok(None));
     }
 

--- a/src-tauri/src/tts/stream.rs
+++ b/src-tauri/src/tts/stream.rs
@@ -40,6 +40,8 @@ pub enum ChunkItem {
     Pcm(Vec<u8>),
     /// Complete snapshot so far; offsets and times are relative to this request.
     Captions(super::captions::CaptionAlignment),
+    /// Rejected optional metadata invalidates the retained snapshot, not audio.
+    ClearCaptions,
     /// The synthesis failed mid-stream; carries a human-readable reason.
     /// Constructed by native-streaming backends (later slice tasks).
     #[allow(dead_code)]
@@ -133,8 +135,12 @@ pub fn chunk_stream_from_speech(
 
     let (tx, rx) = mpsc::channel();
     if let Some(captions) = speech.captions {
-        captions.validate().map_err(TtsError::Http)?;
-        let _ = tx.send(ChunkItem::Captions(captions));
+        match captions.validate() {
+            Ok(()) => {
+                let _ = tx.send(ChunkItem::Captions(captions));
+            }
+            Err(error) => log::warn!("Ignoring invalid batch captions: {error}"),
+        }
     }
     let _ = tx.send(ChunkItem::Pcm(pcm));
     drop(tx); // closing the sender signals end-of-stream after the single chunk
@@ -153,9 +159,15 @@ pub fn collect_speech(stream: ChunkStream) -> Result<super::captions::SpeechAudi
         match item {
             ChunkItem::Pcm(bytes) => pcm.extend_from_slice(&bytes),
             ChunkItem::Captions(value) => {
-                value.validate().map_err(TtsError::Http)?;
-                captions = Some(value);
+                captions = match value.validate() {
+                    Ok(()) => Some(value),
+                    Err(error) => {
+                        log::warn!("Ignoring invalid stream captions: {error}");
+                        None
+                    }
+                };
             }
+            ChunkItem::ClearCaptions => captions = None,
             ChunkItem::Failed(reason) => return Err(TtsError::Http(reason)),
         }
     }
@@ -222,6 +234,128 @@ mod tests {
         .unwrap();
         assert_eq!(speech.bytes, bytes);
         assert_eq!(speech.captions, Some(captions));
+    }
+
+    #[test]
+    fn invalid_batch_captions_do_not_reject_valid_wav() {
+        let bytes = build_wav(8000, 1, 16, &[1, 2, 3, 4]);
+        let captions = super::super::captions::CaptionAlignment {
+            text: "Hi".into(),
+            words: vec![super::super::captions::WordTiming {
+                text_start: 0,
+                text_end: 3,
+                start_ms: 0.0,
+                end_ms: 1.0,
+            }],
+        };
+        assert!(captions.validate().is_err());
+        let speech = collect_speech(
+            chunk_stream_from_speech(super::super::captions::SpeechAudio {
+                bytes: bytes.clone(),
+                captions: Some(captions),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(speech.bytes, bytes);
+        assert_eq!(speech.captions, None);
+    }
+
+    #[test]
+    fn invalid_snapshot_clears_collected_captions_without_losing_pcm() {
+        let valid = super::super::captions::CaptionAlignment {
+            text: "Hi".into(),
+            words: vec![super::super::captions::WordTiming {
+                text_start: 0,
+                text_end: 2,
+                start_ms: 0.0,
+                end_ms: 0.1,
+            }],
+        };
+        let mut invalid = valid.clone();
+        invalid.words[0].start_ms = -1.0;
+        let (tx, rx) = mpsc::channel();
+        for item in [
+            ChunkItem::Captions(valid.clone()),
+            ChunkItem::Pcm(vec![1, 2]),
+            ChunkItem::Captions(invalid),
+            ChunkItem::Pcm(vec![3, 4]),
+        ] {
+            tx.send(item).unwrap();
+        }
+        drop(tx);
+        let meta = AudioFormatMeta {
+            sample_rate: 8000,
+            channels: 1,
+            bits_per_sample: 16,
+        };
+        let speech = collect_speech(ChunkStream::new(meta, rx)).unwrap();
+        assert_eq!(speech.bytes, build_wav(8000, 1, 16, &[1, 2, 3, 4]));
+        assert_eq!(speech.captions, None);
+
+        let next = collect_speech(
+            chunk_stream_from_speech(super::super::captions::SpeechAudio {
+                bytes: build_wav(8000, 1, 16, &[5, 6]),
+                captions: Some(valid.clone()),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(next.captions, Some(valid));
+    }
+
+    #[test]
+    fn provider_caption_clear_removes_the_collected_snapshot() {
+        let captions = super::super::captions::CaptionAlignment {
+            text: "Hi".into(),
+            words: vec![super::super::captions::WordTiming {
+                text_start: 0,
+                text_end: 2,
+                start_ms: 0.0,
+                end_ms: 0.1,
+            }],
+        };
+        let (tx, rx) = mpsc::channel();
+        for item in [
+            ChunkItem::Captions(captions),
+            ChunkItem::Pcm(vec![1, 2]),
+            ChunkItem::ClearCaptions,
+            ChunkItem::Pcm(vec![3, 4]),
+        ] {
+            tx.send(item).unwrap();
+        }
+        drop(tx);
+        let meta = AudioFormatMeta {
+            sample_rate: 8000,
+            channels: 1,
+            bits_per_sample: 16,
+        };
+        let speech = collect_speech(ChunkStream::new(meta, rx)).unwrap();
+        assert_eq!(speech.captions, None);
+        assert_eq!(speech.bytes, build_wav(8000, 1, 16, &[1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn collection_still_rejects_empty_audio_and_explicit_failure() {
+        for items in [
+            vec![],
+            vec![
+                ChunkItem::Pcm(vec![1, 2]),
+                ChunkItem::Failed("engine failed".into()),
+            ],
+        ] {
+            let (tx, rx) = mpsc::channel();
+            for item in items {
+                tx.send(item).unwrap();
+            }
+            drop(tx);
+            let meta = AudioFormatMeta {
+                sample_rate: 8000,
+                channels: 1,
+                bits_per_sample: 16,
+            };
+            assert!(collect_speech(ChunkStream::new(meta, rx)).is_err());
+        }
     }
 
     /// Build a minimal valid WAV: RIFF header + fmt chunk + data chunk.

--- a/src/lib/components/engine/profile-manager.svelte
+++ b/src/lib/components/engine/profile-manager.svelte
@@ -28,6 +28,7 @@
     AppConfig,
     EngineCatalogEntry,
     EngineOptionDescriptor,
+    EngineOptionValue,
     TtsEngine,
     EffectId,
     VoiceCatalogEntry,
@@ -71,7 +72,7 @@
     engine: TtsEngine;
     voice: string;
     voiceLabel: string;
-    engineOptions: Record<string, unknown>;
+    engineOptions: Record<string, EngineOptionValue>;
   }[] = [
     {
       name: "Kitten TTS — Rosie",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,6 +157,10 @@ export interface ProfileEffects {
   active_effect: EffectId;
 }
 
+// Engine options are flat scalar settings written by the catalog UI and read by
+// the Rust side; nested payloads are not part of the contract.
+export type EngineOptionValue = string | number | boolean | string[] | null;
+
 export interface VoiceProfile {
   id: string;
   name: string;
@@ -167,7 +171,7 @@ export interface VoiceProfile {
   speed: number;
   pitch: number;
   effects: ProfileEffects;
-  engine_options: Record<string, unknown>;
+  engine_options: Record<string, EngineOptionValue>;
 }
 
 // ── Engine catalog (returned by list_tts_engines IPC) ────────────────────────
@@ -177,7 +181,7 @@ export interface EngineOptionDescriptor {
   label: string;
   kind: string;
   help: string;
-  default_value: unknown;
+  default_value: EngineOptionValue;
   choices?: string[];
 }
 
@@ -394,6 +398,14 @@ export interface HistoryItemStatus {
   percentage: number;
 }
 
+// Metadata keys the app reads back (fragment ordering, display title). The Rust
+// side may attach more, but only these are consumed in the frontend.
+export interface HistoryItemMetadata {
+  fragment_index?: number;
+  fragment_total?: number;
+  title?: string;
+}
+
 export interface HistoryItem {
   id: string;
   timestamp: number; // Unix timestamp in milliseconds
@@ -413,7 +425,7 @@ export interface HistoryItem {
   error_message?: string;
   attempts: number;
   tags?: string[];
-  metadata?: Record<string, unknown>;
+  metadata?: HistoryItemMetadata;
 }
 
 export interface HistoryFilters {

--- a/src/lib/utils/text.ts
+++ b/src/lib/utils/text.ts
@@ -4,7 +4,7 @@ const ELLIPSIS = "\u2026";
 
 export function formatTextForDisplay(text: string): string {
   return text
-    .replace(/([^\.\!\?\;\:\,])\n/g, "$1. ")
+    .replace(/([^.!?;:,])\n/g, "$1. ")
     .replace(/\n/g, " ")
     .trim()
     .substring(0, MAX_DISPLAY_LENGTH);


### PR DESCRIPTION
## Summary
- Unusable optional caption metadata (invalid ElevenLabs alignment, invalid daemon caption frames, failed validation) now degrades to a caption clear instead of rejecting valid PCM audio
- New ChunkItem::ClearCaptions propagates caption clears to live, cache, and history consumers; audio/protocol errors stay fatal
- Concatenation drops fragments with invalid or missing/empty timings but keeps their source text so later words retain joined text offsets
- Tightened engine_options / history metadata types in the frontend (with the one compile fix this surfaced)

## Test plan
- bun run check: svelte-check 0 errors (vp lint's 179 anti-slop findings are pre-existing on the base branch)
- bun run test: 62 passed
- cargo test (src-tauri): 252 passed, including new degradation tests
